### PR TITLE
v4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+### v4.1.0
+###### June 2, 2026
+*   Added
+    *   Added a new query option to `/players/search?` that allows you to search for specific Twitch names.
+    *   Added a new `/{id}/import-issues` endpoint that allows mods to see what invalidation were raised when the run was imported from SRC.
+    *   Added additional logic to remove speedruns that were deleted from SRC.
+    *   Added additional checks to Celery tasks so it doesn't re-iterate the same runs over and over and over and over and over and over and over and over and over and over and over and over...
+
+*   Fixed
+    *   Fixed an issue where uploading runs from thps.run would fail when converting DateTimeFields.
+    *   Fixed an issue where `vid_status` was missing from POST `/runs`
+    *   Fixed an issue where POST `/runs` did not ingest `*_secs` and self-create the human-friendly form of times.
+    *   Fixed an issue where Celery tasks, in some situations, would call the wrong world record from the wrong category, calculate off of that, and report a point total that was insanely high (one example had a run get 408 MILLION HOLY).
+    *   Fixed an issue where PUT'ing variables to `/runs` would cause issues with validation if the run was a legacy run.
+
 ### v4 - The Definitive Update
 ###### June 1, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### v4.1.0
 ###### June 2, 2026
 *   Added
+    *   Added time-based one-time passwords (TOTP) to the Security panel.
+        *   TOTPs are required for moderators of games and super users.
+            *   Using a Passkey exempts you from needing TOTP.
+        *   Also added recovery code support.
     *   Added a new query option to `/players/search?` that allows you to search for specific Twitch names.
     *   Added a new `/{id}/import-issues` endpoint that allows mods to see what invalidation were raised when the run was imported from SRC.
     *   Added additional logic to remove speedruns that were deleted from SRC.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # thps.run Website - Backend
-## Version 4.0
+## Version 4.1
 
 ![Django](https://img.shields.io/badge/Django-6.0-green.svg?logo=django&logoColor=white)
 ![Django Ninja](https://img.shields.io/badge/1.6-blue?color=black&label=django-ninja&logo=fastapi&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17.4-green?logo=postgresql&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17.10-green?logo=postgresql&logoColor=white)
 
 ### What the heck is this??
 This has been the pet project of [ThePackle](https://twitch.tv/thepackle) for a few years now. In short, it is a highly-customizable, easy-to-use, and curated website that aims to mimic a lot of the leaderboard functionality seen from [HaloRuns](https://haloruns.com). Built entirely in Django (Python), this is the open-source files used for websites like [thps.run](https://thps.run).  

--- a/backend/accounts/adapters.py
+++ b/backend/accounts/adapters.py
@@ -30,6 +30,7 @@ from accounts.oauth_reauth import handle_reauth
 from accounts.oauth_reauth import peek_intent as peek_reauth_intent
 from accounts.oauth_signup import handle_signup
 from accounts.oauth_signup import peek_intent as peek_signup_intent
+from accounts.privileges import social_login_requires_mfa
 
 TWITCH_LOGIN_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_]{1,25}$")
 
@@ -169,7 +170,9 @@ class MFAAdapter(DefaultMFAAdapter):
         if request is not None:
             methods = request.session.get(AUTHENTICATION_METHODS_SESSION_KEY, [])
             if methods and methods[-1].get("method") == "socialaccount":
-                return False
+                if not social_login_requires_mfa(user):
+                    return False
+                return super().is_mfa_enabled(user, types=types)
 
         return super().is_mfa_enabled(user, types=types)
 

--- a/backend/accounts/middleware.py
+++ b/backend/accounts/middleware.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse, JsonResponse
 
+from accounts.privileges import is_gated
 from accounts.turnstile import TurnstileUnavailable, verify_turnstile
 
 logger = logging.getLogger("accounts.turnstile")
@@ -205,4 +206,53 @@ class PathRateLimitMiddleware:
             )
             return _rate_limit_error(ttl)
 
+        return self.get_response(request)
+
+
+class MFASetupRequiredMiddleware:
+    """Block privileged users (superusers, game moderators) until they have a TOTP or passkey."""
+
+    ALLOWLISTED_PREFIXES = (
+        "/_allauth/",
+        "/accounts/",
+        "/illiad/",
+    )
+
+    def __init__(
+        self,
+        get_response: Callable[[HttpRequest], HttpResponse],
+    ) -> None:
+        self.get_response = get_response
+
+    def _is_allowlisted(
+        self,
+        path: str,
+    ) -> bool:
+        prefixes = self.ALLOWLISTED_PREFIXES + (
+            settings.STATIC_URL,
+            settings.MEDIA_URL,
+        )
+        return any(prefix and path.startswith(prefix) for prefix in prefixes)
+
+    def __call__(
+        self,
+        request: HttpRequest,
+    ) -> HttpResponse:
+        if (
+            getattr(settings, "MFA_ENFORCE_FOR_PRIVILEGED", True)
+            and request.user.is_authenticated
+            and not self._is_allowlisted(request.path)
+            and is_gated(request.user)
+        ):
+            return JsonResponse(
+                {
+                    "status": 403,
+                    "data": {
+                        "flows": [{"id": "mfa_setup_required"}],
+                        "accepted_types": ["totp", "webauthn"],
+                    },
+                    "meta": {"is_authenticated": True},
+                },
+                status=403,
+            )
         return self.get_response(request)

--- a/backend/accounts/privileges.py
+++ b/backend/accounts/privileges.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+
+from allauth.mfa.models import Authenticator
+from django.core.cache import cache
+from srl.models.games import Games
+
+PRIVILEGED_CACHE_KEY = "mfa:privileged:{user_id}"
+HASFACTOR_CACHE_KEY = "mfa:hasfactor:{user_id}"
+CACHE_TTL = 300
+
+
+def compute_privileged(
+    user: Any,
+) -> bool:
+    if getattr(user, "is_superuser", False):
+        return True
+    player = getattr(user, "player", None)
+    if player is None:
+        return False
+
+    return Games.objects.filter(moderators=player).exists()
+
+
+def is_privileged_user(
+    user: Any,
+) -> bool:
+    if not getattr(user, "is_authenticated", False):
+        return False
+    key = PRIVILEGED_CACHE_KEY.format(user_id=user.pk)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    value = compute_privileged(user)
+    cache.set(key, value, CACHE_TTL)
+    return value
+
+
+def compute_has_required_factor(
+    user: Any,
+) -> bool:
+    return Authenticator.objects.filter(
+        user=user,
+        type__in=[
+            Authenticator.Type.TOTP,
+            Authenticator.Type.WEBAUTHN,
+        ],
+    ).exists()
+
+
+def has_required_factor(
+    user: Any,
+) -> bool:
+    key = HASFACTOR_CACHE_KEY.format(user_id=user.pk)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    value = compute_has_required_factor(user)
+    cache.set(key, value, CACHE_TTL)
+    return value
+
+
+def is_gated(
+    user: Any,
+) -> bool:
+    return is_privileged_user(user) and not has_required_factor(user)
+
+
+def social_login_requires_mfa(
+    user: Any,
+) -> bool:
+    has_totp = Authenticator.objects.filter(
+        user=user,
+        type=Authenticator.Type.TOTP,
+    ).exists()
+    if not has_totp:
+        return False
+    has_passkey = Authenticator.objects.filter(
+        user=user,
+        type=Authenticator.Type.WEBAUTHN,
+    ).exists()
+    return not has_passkey
+
+
+def invalidate_privileged(
+    user_id: int,
+) -> None:
+    cache.delete(PRIVILEGED_CACHE_KEY.format(user_id=user_id))
+
+
+def invalidate_has_required_factor(
+    user_id: int,
+) -> None:
+    cache.delete(HASFACTOR_CACHE_KEY.format(user_id=user_id))

--- a/backend/accounts/signals.py
+++ b/backend/accounts/signals.py
@@ -1,15 +1,21 @@
 import logging
 
 from allauth.account.signals import user_logged_in, user_signed_up
+from allauth.mfa.models import Authenticator
 from allauth.socialaccount.signals import (
     social_account_added,
     social_account_removed,
     social_account_updated,
 )
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
+from srl.models.games import Games
+from srl.models.players import Players
 
 from accounts.adapters import TWITCH_LOGIN_RE
+from accounts.privileges import invalidate_has_required_factor, invalidate_privileged
 
 logger = logging.getLogger(__name__)
 
@@ -134,3 +140,49 @@ def apply_remember_me(
     remember = request.headers.get("X-Remember-Me", "").strip().lower()
     if remember in {"1", "true", "yes"}:
         request.session.set_expiry(REMEMBER_AGE)
+
+
+@receiver(post_save, sender=Authenticator)
+@receiver(post_delete, sender=Authenticator)
+def invalidate_mfa_factor_cache(
+    sender,
+    instance,
+    **kwargs,
+) -> None:
+    invalidate_has_required_factor(instance.user_id)
+
+
+@receiver(m2m_changed, sender=Games.moderators.through)
+def invalidate_mfa_privileged_on_moderators(
+    sender,
+    instance,
+    action,
+    reverse,
+    pk_set,
+    **kwargs,
+) -> None:
+    if action not in {"post_add", "post_remove"}:
+        return
+    if reverse:
+        user_id = getattr(instance, "user_id", None)
+        if user_id is not None:
+            invalidate_privileged(user_id)
+        return
+    if not pk_set:
+        return
+    user_ids = (
+        Players.objects.filter(pk__in=pk_set)
+        .exclude(user__isnull=True)
+        .values_list("user_id", flat=True)
+    )
+    for user_id in user_ids:
+        invalidate_privileged(user_id)
+
+
+@receiver(post_save, sender=get_user_model())
+def invalidate_mfa_privileged_on_user_save(
+    sender,
+    instance,
+    **kwargs,
+) -> None:
+    invalidate_privileged(instance.pk)

--- a/backend/api/backability.py
+++ b/backend/api/backability.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from srl.models.games import Games
-
 from api.models import APIKey
 from api.permissions import CAPABILITY_SCOPED, MOD_SCOPES, PLAYER_SCOPES, SU_ONLY_SCOPES
 
@@ -52,9 +50,5 @@ def is_key_backable(
 def _user_moderates_any_game(
     user: Any,
 ) -> bool:
-    if getattr(user, "is_superuser", False):
-        return True
-    player = getattr(user, "player", None)
-    if player is None:
-        return False
-    return Games.objects.filter(moderators=player).exists()
+    from accounts.privileges import compute_privileged
+    return compute_privileged(user)

--- a/backend/api/v1/routers/auth/submissions.py
+++ b/backend/api/v1/routers/auth/submissions.py
@@ -1,8 +1,12 @@
 import logging
+from datetime import datetime
 
 import requests as http_requests
+from django.conf import settings
 from django.db import transaction
 from django.http import HttpRequest
+from django.utils import timezone
+from django.utils.dateparse import parse_date, parse_datetime
 from ninja import Router, Status
 from srl.encryption import decrypt_src_key
 from srl.leaderboard.trigger import recalculate_run
@@ -153,6 +157,26 @@ def _build_src_run_payload(
         }
 
     return {"run": run_data}
+
+
+def _parse_submission_date(
+    raw_date: str | None,
+) -> datetime | None:
+    """Parse an SRC submission date (YYYY-MM-DD or ISO 8601) into an aware datetime
+
+    SRC keeps the raw string, but the Runs.date DateTimeField needs a real datetime so the
+    post_save notification signal can compare it against a cutoff."""
+    if not raw_date:
+        return None
+    parsed = parse_datetime(raw_date)
+    if parsed is None:
+        parsed_date = parse_date(raw_date)
+        if parsed_date is None:
+            return None
+        parsed = datetime.combine(parsed_date, datetime.min.time())
+    if settings.USE_TZ and timezone.is_naive(parsed):
+        parsed = timezone.make_aware(parsed)
+    return parsed
 
 
 @router.get(
@@ -790,6 +814,7 @@ def submit_run(
 
     runtype = "il" if level else "main"
     src_run_url = f"https://www.speedrun.com/run/{src_run_id}"
+    run_date = _parse_submission_date(body.date)
 
     with transaction.atomic():
         run = Runs.objects.create(
@@ -804,7 +829,7 @@ def submit_run(
             url=src_run_url,
             video=body.video,
             vid_status="new",
-            date=body.date,
+            date=run_date,
             description=body.comment,
             time=time_display.get("time"),
             time_secs=time_seconds.get("time_secs"),

--- a/backend/api/v1/routers/resources/players.py
+++ b/backend/api/v1/routers/resources/players.py
@@ -1,3 +1,4 @@
+import re
 from typing import Annotated
 
 from django.db.models import Count, Q, QuerySet, Sum
@@ -28,6 +29,23 @@ from api.v1.schemas.runs import compute_run_subcategory
 from api.v1.utils import get_or_generate_id
 
 router = Router()
+
+
+_TWITCH_URL_PREFIX_RE = re.compile(
+    r"^(?:https?://)?(?:www\.)?twitch\.tv/", re.IGNORECASE
+)
+
+
+def _sanitize_twitch_username(
+    value: str,
+) -> str:
+    """Reduce a Twitch input (bare handle or full URL) to a bare handle."""
+    value = value.strip()
+    value = _TWITCH_URL_PREFIX_RE.sub("", value)
+    value = value.split("?", 1)[0]
+    value = value.split("/", 1)[0]
+    value = value.lstrip("@").strip()
+    return value
 
 
 def apply_player_embeds(
@@ -158,32 +176,54 @@ def apply_player_embeds(
     response={200: list[PlayerSearchResultSchema]},
     summary="Search Players",
     description="""\
-Search for players by name or nickname. Returns lightweight results
-suitable for autocomplete/typeahead.
+Search for players by name/nickname, or look up a player by exact Twitch handle.
+Returns lightweight results suitable for autocomplete/typeahead.
 
 Supported Parameters:
-- `q` (str): Search query (min 2 characters). Matches against name and nickname.
+- `q` (str): Name/nickname search query (min 2 characters). Substring match.
+- `twitch` (str): Exact Twitch handle lookup. Accepts a bare handle or a full
+  Twitch URL (e.g. `Bob` or `https://twitch.tv/Bob`). Match
+  is case-insensitive. Takes precedence over `q` if both are supplied.
 - `limit` (int): Max results to return (default 10, max 25).
+
+At least one of `q` or `twitch` must be supplied; otherwise an empty list is
+returned. An empty list also means "no player matches".
 
 Examples:
 - `/players/search?q=hawk` - Search for players matching "hawk".
-- `/players/search?q=spe&limit=5` - Search with a custom limit.
+- `/players/search?twitch=Bob` - Find the player using that Twitch handle.
 """,
     auth=public_read(),
 )
 def search_players(
     request: HttpRequest,
     q: Annotated[
-        str,
-        Query(min_length=2, max_length=30, description="Search query"),
-    ],
+        str | None,
+        Query(min_length=2, max_length=30, description="Name/nickname search query"),
+    ] = None,
+    twitch: Annotated[
+        str | None,
+        Query(min_length=2, max_length=100, description="Exact Twitch handle or URL"),
+    ] = None,
     limit: Annotated[
         int,
         Query(default=10, ge=1, le=25, description="Max results"),
     ] = 10,
 ) -> Status:
+    if twitch:
+        username = _sanitize_twitch_username(twitch)
+        if not username:
+            return Status(200, [])
+        player_filter = Q(twitch__iendswith=f"/{username}") | Q(
+            twitch__iendswith=f"/{username}/",
+        )
+    elif q:
+        player_filter = Q(name__icontains=q) | Q(nickname__icontains=q)
+    else:
+        return Status(200, [])
+
     players = (
-        Players.objects.filter(Q(name__icontains=q) | Q(nickname__icontains=q))
+        Players.objects.filter(player_filter)
         .select_related("countrycode", "user")
         .order_by("name")[:limit]
     )

--- a/backend/api/v1/routers/resources/runs.py
+++ b/backend/api/v1/routers/resources/runs.py
@@ -842,6 +842,11 @@ def update_run(
         old_timeigt_secs = run.timeigt_secs
         pre_edit_snapshot = snapshot_run(run)
 
+        # Timing gaps that already exist before this edit. A required method missing here is a
+        # pre-existing condition (recorded as a non-blocking import issue post-save), not
+        # something this update introduced, so it must not block an unrelated write.
+        preexisting_missing = set(run.missing_required_methods())
+
         update_data = run_data.model_dump(exclude_unset=True)
 
         time_error = normalize_time_fields(update_data)
@@ -1004,7 +1009,7 @@ def update_run(
                 )
 
             try:
-                run.validate_allowed_method_data()
+                run.validate_allowed_method_data(ignore=preexisting_missing)
             except ValidationError:
                 raise
 

--- a/backend/api/v1/routers/resources/runs.py
+++ b/backend/api/v1/routers/resources/runs.py
@@ -40,11 +40,17 @@ from api.v1.routers.utils.embeds import (
     serialize_category_embed,
     serialize_game_embed,
     serialize_level_embed,
+    serialize_platform_embed,
 )
-from api.v1.routers.utils.resolvers import game_from_body, run_from_path
+from api.v1.routers.utils.resolvers import (
+    game_from_body,
+    game_from_run_path,
+    run_from_path,
+)
 from api.v1.schemas.base import ErrorResponse, RunStatusType, RunTypeType
 from api.v1.schemas.runs import (
     RunCreateSchema,
+    RunImportIssuesSchema,
     RunModSchema,
     RunSchema,
     RunUpdateSchema,
@@ -120,6 +126,9 @@ def apply_run_embeds(
     if "level" in embed_fields and run.level:
         embeds["level"] = serialize_level_embed(run.level)
 
+    if "platform" in embed_fields and run.platform:
+        embeds["platform"] = serialize_platform_embed(run.platform)
+
     if "variables" in embed_fields:
         try:
             variables_data = []
@@ -146,6 +155,57 @@ def apply_run_embeds(
             embeds["variables"] = []
 
     return embeds
+
+
+def normalize_time_fields(
+    data: dict,
+) -> Status | None:
+    """Normalize RTA/LRT/IGT display strings from their `*_secs` source of truth.
+
+    Consolidates logic that transforms the `_*secs` times into display strings that can be properly
+    digested on the frontend or through the API."""
+    time_pairs = (
+        ("time", "time_secs"),
+        ("timenl", "timenl_secs"),
+        ("timeigt", "timeigt_secs"),
+    )
+    for str_field, secs_field in time_pairs:
+        has_str = str_field in data
+        has_secs = secs_field in data
+        if not has_str and not has_secs:
+            continue
+
+        if has_secs and data[secs_field] is not None:
+            secs = data[secs_field]
+        elif has_str:
+            raw = data[str_field]
+            if raw in (None, "", "0"):
+                secs = None if raw is None else 0.0
+            else:
+                try:
+                    secs = parse_time(raw)
+                except ValueError:
+                    return Status(
+                        422,
+                        ErrorResponse(
+                            error=f"Invalid time format for {str_field}: {raw!r}",
+                            details=None,
+                        ),
+                    )
+        else:
+            secs = None
+
+        if secs is None:
+            data[str_field] = None
+            data[secs_field] = None
+        elif secs == 0:
+            data[str_field] = "0"
+            data[secs_field] = 0.0
+        else:
+            data[str_field] = convert_time(secs)
+            data[secs_field] = secs
+
+    return None
 
 
 @router.get(
@@ -313,12 +373,13 @@ Supported Embeds:
 - `game`: Includes the metadata of the game related to the run queried.
 - `category`: Includes the metadata of the category related to the run queried.
 - `level`: Include the metadata of the level related to the run queried (if an IL run).
+- `platform`: Include the metadata of the platform the run was played on.
 - `variables`: Include the metadata of the variables and values related to the run.
 
 Examples:
 - `/runs/y8dwozoj` - Basic run data with players.
 - `/runs/y8dwozoj?embed=game` - Include game metadata.
-- `/runs/y8dwozoj?embed=game,category,variables` - Full run details with embeds.
+- `/runs/y8dwozoj?embed=game,category,platform,variables` - Full run details with embeds.
 """,
     auth=public_read(),
 )
@@ -389,6 +450,56 @@ def get_run(
         )
 
 
+@router.get(
+    "/{id}/import-issues",
+    response={
+        200: RunImportIssuesSchema,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        404: ErrorResponse,
+        500: ErrorResponse,
+    },
+    summary="Get Run Import Issues",
+    description="""\
+Retrieve the import validation flags for a single run.
+
+Requires an API key (or session) with the `games.audit.view` capability scoped to the run's
+game. Returns only the run id and its import issue flags; fetch `GET /runs/{id}` separately
+for game, category, and player context.
+""",
+    auth=authed("games.audit.view", target_resolver=game_from_run_path),
+)
+def get_run_import_issues(
+    request: HttpRequest,
+    id: str,
+) -> Status:
+    try:
+        run = (
+            Runs.objects.filter(id__iexact=id)
+            .only("id", "has_import_issues", "import_issues")
+            .first()
+        )
+        if not run:
+            return Status(
+                404,
+                ErrorResponse(
+                    error="Run ID does not exist",
+                    details=None,
+                ),
+            )
+
+        return Status(200, RunImportIssuesSchema.model_validate(run))
+
+    except Exception as e:
+        return Status(
+            500,
+            ErrorResponse(
+                error="Failed to retrieve run import issues",
+                details={"exception": str(e)},
+            ),
+        )
+
+
 @router.post(
     "/",
     response={
@@ -416,6 +527,8 @@ Request Body:
 - `player_ids` (list[str] | None): List of player IDs in order of participation.
 - `runtype` (str): Run type (`main` or `il`).
 - `place` (int): Leaderboard position.
+- `vid_status` (str): Verification state (`verified`, `new`, `rejected`, or `review`);
+  defaults to `verified`.
 - `time` (str | None): Formatted time string (e.g., "1:23.456").
 - `time_secs` (float | None): Time in seconds (for sorting/calculations).
 - `video` (str | None): Video URL.
@@ -563,6 +676,10 @@ def create_run(
             }
         )
         create_data["id"] = run_id
+
+        time_error = normalize_time_fields(create_data)
+        if time_error:
+            return time_error
 
         with transaction.atomic():
             run = Runs.objects.create(
@@ -727,44 +844,9 @@ def update_run(
 
         update_data = run_data.model_dump(exclude_unset=True)
 
-        time_pairs = (
-            ("time", "time_secs"),
-            ("timenl", "timenl_secs"),
-            ("timeigt", "timeigt_secs"),
-        )
-        for str_field, secs_field in time_pairs:
-            has_str = str_field in update_data
-            has_secs = secs_field in update_data
-            if not has_str and not has_secs:
-                continue
-
-            if has_secs:
-                secs = update_data[secs_field]
-            else:
-                raw = update_data[str_field]
-                if raw in (None, "", "0"):
-                    secs = None if raw is None else 0.0
-                else:
-                    try:
-                        secs = parse_time(raw)
-                    except ValueError:
-                        return Status(
-                            422,
-                            ErrorResponse(
-                                error=f"Invalid time format for {str_field}: {raw!r}",
-                                details=None,
-                            ),
-                        )
-
-            if secs is None:
-                update_data[str_field] = None
-                update_data[secs_field] = None
-            elif secs == 0:
-                update_data[str_field] = "0"
-                update_data[secs_field] = 0.0
-            else:
-                update_data[str_field] = convert_time(secs)
-                update_data[secs_field] = secs
+        time_error = normalize_time_fields(update_data)
+        if time_error:
+            return time_error
 
         if "game_id" in update_data:
             game = Games.objects.filter(id=update_data["game_id"]).first()

--- a/backend/api/v1/routers/utils/embeds.py
+++ b/backend/api/v1/routers/utils/embeds.py
@@ -1,6 +1,7 @@
 from srl.models.categories import Categories
 from srl.models.games import Games
 from srl.models.levels import Levels
+from srl.models.platforms import Platforms
 
 from api.v1.schemas.base import VALID_EMBEDS, validate_embeds
 
@@ -79,4 +80,15 @@ def serialize_level_embed(
         "slug": level.slug,
         "url": level.url,
         "rules": level.rules,
+    }
+
+
+def serialize_platform_embed(
+    platform: Platforms,
+) -> dict:
+    """Standard embed payload for a `Platforms` instance."""
+    return {
+        "id": platform.id,
+        "name": platform.name,
+        "slug": platform.slug,
     }

--- a/backend/api/v1/routers/utils/resolvers.py
+++ b/backend/api/v1/routers/utils/resolvers.py
@@ -121,6 +121,17 @@ def game_from_level_path(
     return level.game if level else None
 
 
+def game_from_run_path(
+    request: HttpRequest,
+) -> Games | None:
+    kwargs = _path_kwargs(request)
+    run_id = kwargs.get("run_id") or kwargs.get("id")
+    if run_id is None:
+        return None
+    run = Runs.objects.filter(pk=run_id).select_related("game").first()
+    return run.game if run else None
+
+
 def game_from_variable_path(
     request: HttpRequest,
 ) -> Games | None:

--- a/backend/api/v1/schemas/base.py
+++ b/backend/api/v1/schemas/base.py
@@ -100,7 +100,7 @@ VALID_EMBEDS: dict[str, set[str]] = {
     "levels": {"game", "variables", "values"},
     "variables": {"game", "category", "level", "values"},
     "players": {"country", "stats", "awards", "runs", "profile", "profile-obsolete"},
-    "runs": {"game", "category", "level", "variables"},
+    "runs": {"game", "category", "level", "platform", "variables"},
     "guides": {"game", "tags"},
     "tags": set(),
 }

--- a/backend/api/v1/schemas/runs.py
+++ b/backend/api/v1/schemas/runs.py
@@ -119,7 +119,8 @@ class RunBaseSchema(BaseEmbedSchema):
         place (int): Leaderboard position.
         subcategory (str | None): Human-readable subcategory description.
         times (RunTimesSchema): Nested timing data (RTA, LRT, IGT, primary).
-        platform (str | None): SRC platform ID; null if no platform recorded.
+        platform (str | dict | None): SRC platform ID (default) or full platform info with
+            ?embed=platform; null if no platform recorded.
         emulated (bool): Whether the run was played on an emulator.
         description (str | None): Run notes/description.
         video (str | None): YouTube/Twitch URL.
@@ -150,10 +151,9 @@ class RunBaseSchema(BaseEmbedSchema):
         description="Human-readable subcategory combo",
     )
     times: RunTimesSchema = Field(description="Nested timing data")
-    platform: str | None = Field(
+    platform: str | dict | None = Field(
         default=None,
-        max_length=10,
-        description="SRC platform ID; null if none recorded",
+        description="SRC platform ID (default) or full platform info with ?embed=platform",
     )
     emulated: bool = Field(
         default=False,
@@ -188,9 +188,11 @@ class RunBaseSchema(BaseEmbedSchema):
     def convert_platform_to_id(
         cls,
         v: Any,
-    ) -> str | None:
+    ) -> str | dict | None:
         if v is None:
             return None
+        if isinstance(v, dict):
+            return v
         if isinstance(v, str):
             return v
         if hasattr(v, "id"):
@@ -406,6 +408,34 @@ class RunModSchema(RunSchema):
     )
 
 
+class RunImportIssuesSchema(Schema):
+    """Minimal payload exposing a single run's import validation flags (authed audit)."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "y8dwozoj",
+                "has_import_issues": True,
+                "import_issues": [
+                    {"type": "missing_timing_methods", "methods": ["rta"]},
+                ],
+            },
+        },
+    )
+
+    id: str = Field(
+        description="Run ID.",
+    )
+    has_import_issues: bool = Field(
+        default=False,
+        description="True when the run has one or more unresolved import issues.",
+    )
+    import_issues: list[dict] = Field(
+        default_factory=list,
+        description="Import-time validation issues detected for this run.",
+    )
+
+
 class PlayerRunEmbedSchema(RunBaseSchema):
     """Schema for embedding run data in player profile responses.
 
@@ -476,6 +506,7 @@ class RunCreateSchema(BaseEmbedSchema):
         player_ids (list[str] | None): List of player IDs in order of participation.
         runtype (str): Run type (main or il).
         place (int): Leaderboard position.
+        vid_status (str): SRC verification state (verified, new, rejected); defaults to verified.
         time (str | None): Formatted time string.
         time_secs (float | None): Time in seconds.
         video (str | None): Video URL.
@@ -494,6 +525,10 @@ class RunCreateSchema(BaseEmbedSchema):
     player_ids: list[str] | None = Field(None, description="In order of participation")
     runtype: RunTypeType = Field(...)
     place: int = Field(..., ge=1)
+    vid_status: RunStatusType = Field(
+        default="verified",
+        description="SRC verification state: verified, new, or rejected. Can be review from site.",
+    )
     time: str | None = Field(default=None, max_length=25)
     time_secs: float | None = Field(default=None, ge=0)
     timenl: str | None = Field(default=None, max_length=25)

--- a/backend/notifications/signals.py
+++ b/backend/notifications/signals.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from auditlog.context import get_actor
@@ -132,8 +132,12 @@ def runs_trigger_review_notification(
 
     max_age_days = getattr(settings, "AWAITING_REVIEW_NOTIFY_MAX_AGE_DAYS", 7)
     run_date = getattr(instance, "date", None)
-    if run_date is not None:
+    if isinstance(run_date, datetime):
         cutoff = timezone.now() - timedelta(days=max_age_days)
+        if timezone.is_aware(cutoff) and timezone.is_naive(run_date):
+            run_date = timezone.make_aware(run_date)
+        elif timezone.is_naive(cutoff) and timezone.is_aware(run_date):
+            run_date = timezone.make_naive(run_date)
         if run_date < cutoff:
             return
 

--- a/backend/srl/models/runs.py
+++ b/backend/srl/models/runs.py
@@ -295,18 +295,37 @@ class Runs(models.Model):
     ) -> list[str]:
         return self._resolved_timing().required_methods
 
+    def missing_required_methods(
+        self,
+    ) -> list[str]:
+        """Return resolved required timing methods that are missing or zero on this run."""
+        missing: list[str] = []
+        for method in self._resolved_required_methods():
+            _, secs_field = self._TIMING_FIELD_MAP[method]
+            value = getattr(self, secs_field)
+            if not value or value <= 0:
+                missing.append(method)
+        return missing
+
     def validate_allowed_method_data(
         self,
+        *,
+        ignore: set[str] | None = None,
     ) -> None:
         """Enforce that the run has data for every resolved "allowed" timing method.
 
         Resolves the `Game` -> `Category` -> `Variable` -> `VariableValue` chain to resolve if
         the run has the `required_methods`. Missing or zero values on any resolved method
-        will raise a ValidationError.
+        will raise a ValidationError. Methods in `ignore` (gaps that already existed before an
+        edit) are not enforced, so an unrelated update is not blocked by a pre-existing timing
+        gap it did not introduce.
         """
+        ignore = ignore or set()
         allowed = self._resolved_required_methods()
         missing: list[str] = []
         for method in allowed:
+            if method in ignore:
+                continue
             _, secs_field = self._TIMING_FIELD_MAP[method]
             value = getattr(self, secs_field)
             if not value or value <= 0:
@@ -322,12 +341,7 @@ class Runs(models.Model):
     ) -> list[dict]:
         """Return import-time validation issues for this run without raising."""
         issues: list[dict] = []
-        missing: list[str] = []
-        for method in self._resolved_required_methods():
-            _, secs_field = self._TIMING_FIELD_MAP[method]
-            value = getattr(self, secs_field)
-            if not value or value <= 0:
-                missing.append(method)
+        missing = self.missing_required_methods()
         if missing:
             issues.append(
                 {

--- a/backend/srl/srcom/leaderboards.py
+++ b/backend/srl/srcom/leaderboards.py
@@ -549,6 +549,8 @@ def sync_run(
                 base_wr_query = filter_by_variable_map(
                     Runs.objects.filter(
                         game=context_data.game_id,
+                        category_id=context_data.category_id,
+                        level_id=context_data.level_id,
                         obsolete=False,
                         place=1,
                     ),

--- a/backend/srl/tasks/src_discover.py
+++ b/backend/srl/tasks/src_discover.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timezone as dt_timezone
 from typing import Any
 
 from celery import shared_task
@@ -12,6 +13,7 @@ from srl.models import (
     Categories,
     Games,
     Levels,
+    Platforms,
     Players,
     RunPlayers,
     Runs,
@@ -27,7 +29,7 @@ from srl.srcom.reconciliation import reconciliation_upsert_check
 from srl.srcom.schema.src import SrcRunsModel
 from srl.srcom.utils import create_run_default
 from srl.srcom.variables import sync_variables
-from srl.utils import src_api
+from srl.utils import src_api, src_api_probe
 
 log = logging.getLogger(__name__)
 
@@ -201,6 +203,85 @@ def _call_lightweight_upsert(
     return success_reason
 
 
+# This batch of code is mainly to help identify if an SRC run's metadata is unchanged versus what
+# we have in the local DB. The reason for this is, if we import runs and they are verified, then it
+# would kick off recalculations of points and standings. The current code is kinda bad in that it
+# will blindly ingest those runs, but these functions will help verify local vs SRC; if there is a
+# change then it is ingested and recalculation can happen, and if not then we can ignore it.
+def _norm_dt(
+    value: Any,
+) -> Any:
+    """Normalize a datetime to UTC at second precision for stable comparison."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=dt_timezone.utc)
+    return value.astimezone(dt_timezone.utc).replace(microsecond=0)
+
+
+def _ne_secs(
+    src_val: Any,
+    local_val: Any,
+) -> bool:
+    """True when two second-values differ at millisecond precision (None treated as 0)."""
+    return round(float(src_val or 0.0), 3) != round(float(local_val or 0.0), 3)
+
+
+def _ne_platform(
+    src_platform: str | None,
+    local_platform_id: str | None,
+) -> bool:
+    """True when the SRC platform differs from the stored platform."""
+    src_platform = src_platform or None
+    if src_platform == local_platform_id:
+        return False
+    if (
+        src_platform is not None
+        and not Platforms.objects.filter(id=src_platform).exists()
+    ):
+        src_platform = None
+    return src_platform != local_platform_id
+
+
+def _src_run_unchanged(
+    payload: dict[str, Any],
+    local: Runs,
+) -> bool:
+    """True when the SRC payload matches the stored run on every sync-sourced field.
+
+    Compares only the fields create_run_default writes from SRC. Derived fields and the
+    player/value tables are not compared. If a validation error occurs or another hicup comes up,
+    then we will just assume the run needs to be re-applied to the local DB."""
+    try:
+        model = SrcRunsModel.model_validate(payload)
+    except Exception:
+        return False
+    try:
+        if model.status.status != local.vid_status:
+            return False
+        if _ne_secs(model.times.realtime_t, local.time_secs):
+            return False
+        if _ne_secs(model.times.realtime_noloads_t, local.timenl_secs):
+            return False
+        if _ne_secs(model.times.ingame_t, local.timeigt_secs):
+            return False
+        if (model.video_uri or None) != (local.video or None):
+            return False
+        if (model.comment or None) != (local.description or None):
+            return False
+        if bool(model.system.emulated) != bool(local.emulated):
+            return False
+        if _ne_platform(model.system.platform, local.platform_id):
+            return False
+        if _norm_dt(model.date) != _norm_dt(local.date):
+            return False
+        if _norm_dt(model.status.verify_date) != _norm_dt(local.v_date):
+            return False
+    except Exception:
+        return False
+    return True
+
+
 def _process_run_payload(
     payload: dict[str, Any],
     src_status: str,
@@ -214,7 +295,23 @@ def _process_run_payload(
     if target_status is None:
         return "unknown_status"
 
-    local = Runs.objects.filter(id=run_id).only("id", "vid_status").first()
+    local = (
+        Runs.objects.filter(id=run_id)
+        .only(
+            "id",
+            "vid_status",
+            "time_secs",
+            "timenl_secs",
+            "timeigt_secs",
+            "video",
+            "description",
+            "date",
+            "v_date",
+            "platform",
+            "emulated",
+        )
+        .first()
+    )
 
     if local is None:
         if not _ensure_dependencies(payload):
@@ -231,6 +328,9 @@ def _process_run_payload(
     if target_status == Runs.VidStatus.NEW:
         return "skip_still_new"
 
+    if _src_run_unchanged(payload, local):
+        return "skipped_unchanged"
+
     if not _ensure_dependencies(payload):
         return "deps_missing"
 
@@ -241,6 +341,85 @@ def _process_run_payload(
         payload,
         Runs.VidStatus.REJECTED,
         "rejected_refreshed",
+    )
+
+
+def _reconcile_deleted_unverified_runs(
+    game_id: str,
+    src_new_ids: set[str],
+    counts: dict[str, int],
+) -> None:
+    """Remove local unverified runs that SRC no longer reports as existing."""
+    local_unverified = list(
+        Runs.objects.filter(
+            game=game_id,
+            vid_status__in=(Runs.VidStatus.NEW, Runs.VidStatus.REVIEW),
+        ).values_list("id", flat=True),
+    )
+
+    for run_id in local_unverified:
+        if run_id in src_new_ids:
+            continue
+
+        status_code, envelope = src_api_probe(f"{_V1_RUNS_URL}/{run_id}")
+
+        if status_code == 404:
+            _remove_deleted_run(run_id)
+            counts["deleted_on_src"] = counts.get("deleted_on_src", 0) + 1
+            continue
+
+        if status_code != 200 or not isinstance(envelope, dict):
+            log.warning(
+                "src_discover: probe for run=%s game=%s returned %s; skipping",
+                run_id,
+                game_id,
+                status_code,
+            )
+            counts["probe_failed"] = counts.get("probe_failed", 0) + 1
+            continue
+
+        run_payload = envelope.get("data")
+        current_status = (
+            (run_payload.get("status") or {}).get("status")
+            if isinstance(run_payload, dict)
+            else None
+        )
+        if (
+            not isinstance(run_payload, dict)
+            or current_status not in _SRC_TO_LOCAL_STATUS
+        ):
+            counts["probe_unknown"] = counts.get("probe_unknown", 0) + 1
+            continue
+
+        try:
+            reason = _process_run_payload(run_payload, current_status)
+        except Exception as exc:
+            log.warning(
+                "src_discover: reconcile of run=%s game=%s failed: %s",
+                run_id,
+                game_id,
+                exc,
+            )
+            reason = "reconcile_failed"
+        counts[reason] = counts.get(reason, 0) + 1
+
+
+def _remove_deleted_run(
+    run_id: str,
+) -> None:
+    """Hard-delete a local run confirmed deleted on SRC, plus its notifications."""
+    from notifications.models import Notification
+
+    with transaction.atomic():
+        Notification.objects.filter(
+            target_type="run",
+            target_id=str(run_id),
+        ).delete()
+        Runs.objects.filter(id=run_id).delete()
+
+    log.info(
+        "src_discover: removed run=%s deleted on SRC",
+        run_id,
     )
 
 
@@ -257,6 +436,11 @@ def discover_runs(
         ("verified", "verify-date"),
         ("rejected", "verify-date"),
     ]
+
+    # Tracks SRC Run IDs that report as `new` so we can detect if the local database has different
+    # runs known. If SRC is dead, just returns none and nothing happens.
+    src_new_ids: set[str] | None = None
+    new_truncated = False
 
     for src_status, orderby in statuses:
         url = (
@@ -275,6 +459,13 @@ def discover_runs(
             continue
 
         runs = data if isinstance(data, list) else []
+        if src_status == "new":
+            src_new_ids = {
+                run_id
+                for run_id in (r.get("id") for r in runs if isinstance(r, dict))
+                if run_id
+            }
+            new_truncated = len(runs) >= limit
         for v1_run in runs:
             try:
                 reason = _process_run_payload(v1_run, src_status)
@@ -288,6 +479,13 @@ def discover_runs(
                 )
                 reason = "exception"
             counts[reason] = counts.get(reason, 0) + 1
+
+    if src_new_ids is not None and not new_truncated:
+        _reconcile_deleted_unverified_runs(
+            game_id,
+            src_new_ids,
+            counts,
+        )
 
     log.info(
         "src_discover: game=%s outcomes=%s",

--- a/backend/srl/utils.py
+++ b/backend/srl/utils.py
@@ -108,6 +108,45 @@ def src_api(
     return payload if raw else payload["data"]
 
 
+def src_api_probe(
+    url: str,
+) -> tuple[int, dict | None]:
+    """Probes a Speedrun.com API v1 GET, returning (status_code, payload) without raising.
+
+    Mirrors src_api's retry-on-420/503 behavior, but instead of raising on a non-200 it
+    returns the final HTTP status code so callers can tell a 404 (resource deleted on SRC)
+    apart from a transient failure. The payload is the parsed JSON envelope when the final
+    status is 200, otherwise None.
+
+    Arguments:
+        url (str): The complete URL of the API endpoint being called.
+
+    Returns:
+        tuple[int, dict | None]: The final HTTP status code and, on a 200, the JSON
+            envelope (otherwise None).
+    """
+    response = None
+    for attempt in range(1, SRC_MAX_RETRIES + 1):
+        response = requests.get(url, headers=SRC_HEADERS, timeout=30)
+        if response.status_code not in (420, 503):
+            break
+
+        logger.warning(
+            "SRC rate limit (%s) on attempt %d/%d, sleeping %ds: %s",
+            response.status_code,
+            attempt,
+            SRC_MAX_RETRIES,
+            SRC_BACKOFF_SECS,
+            url,
+        )
+        time.sleep(SRC_BACKOFF_SECS)
+
+    if response.status_code != 200:
+        return response.status_code, None
+
+    return response.status_code, response.json()
+
+
 def src_api_paginate(
     base_url: str,
     page_size: int = 200,
@@ -145,11 +184,16 @@ def points_formula(
     Returns:
         int: Points awarded to the speedrun in comparison to world record.
     """
+    if run <= 0:
+        return 0
     log = 4.8284
     if short:
         log = log * math.sqrt(wr / 60)
-
-    return math.floor(math.pow(math.e, log * ((wr / run) - 1)) * max_points)
+    try:
+        result = math.floor(math.pow(math.e, log * ((wr / run) - 1)) * max_points)
+    except OverflowError:
+        return max_points
+    return min(result, max_points)
 
 
 class TimeDict(TypedDict):

--- a/backend/tests/test_mfa_enforcement.py
+++ b/backend/tests/test_mfa_enforcement.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+
+from allauth.mfa.models import Authenticator
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from accounts.middleware import MFASetupRequiredMiddleware
+from accounts.privileges import is_gated, social_login_requires_mfa
+from srl.models.games import Games
+from srl.models.players import Players
+
+User = get_user_model()
+
+
+def _ok_view(request):
+    return HttpResponse("ok")
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        },
+    },
+    MFA_ENFORCE_FOR_PRIVILEGED=True,
+)
+class MFAEnforcementTests(TestCase):
+    def setUp(self) -> None:
+        cache.clear()
+        self.factory = RequestFactory()
+        self.middleware = MFASetupRequiredMiddleware(_ok_view)
+
+    def _make_user(self, username, is_superuser=False):
+        user = User.objects.create_user(  # type: ignore
+            username=username,
+            email=f"{username}@example.com",
+            password="supersecret123",
+        )
+        if is_superuser:
+            user.is_superuser = True
+            user.is_staff = True
+            user.save(update_fields=["is_superuser", "is_staff"])
+        return user
+
+    def _add_factor(self, user, factor_type):
+        return Authenticator.objects.create(
+            user=user,
+            type=factor_type,
+            data={},
+        )
+
+    def _request(self, user, path="/api/v1/games"):
+        request = self.factory.get(path)
+        request.user = user
+        return self.middleware(request)
+
+    def test_superuser_without_factor_is_gated(self) -> None:
+        user = self._make_user("super1", is_superuser=True)
+        response = self._request(user)
+        self.assertEqual(response.status_code, 403)
+        body = json.loads(response.content)
+        self.assertEqual(body["data"]["flows"][0]["id"], "mfa_setup_required")
+        self.assertEqual(body["data"]["accepted_types"], ["totp", "webauthn"])
+
+    def test_superuser_with_totp_not_gated(self) -> None:
+        user = self._make_user("super2", is_superuser=True)
+        self._add_factor(user, Authenticator.Type.TOTP)
+        self.assertEqual(self._request(user).status_code, 200)
+
+    def test_superuser_with_passkey_not_gated(self) -> None:
+        user = self._make_user("super3", is_superuser=True)
+        self._add_factor(user, Authenticator.Type.WEBAUTHN)
+        self.assertEqual(self._request(user).status_code, 200)
+
+    def test_recovery_codes_only_still_gated(self) -> None:
+        user = self._make_user("super4", is_superuser=True)
+        self._add_factor(user, Authenticator.Type.RECOVERY_CODES)
+        self.assertEqual(self._request(user).status_code, 403)
+
+    def test_non_privileged_user_not_gated(self) -> None:
+        user = self._make_user("plain1")
+        self.assertEqual(self._request(user).status_code, 200)
+
+    def test_anonymous_not_gated(self) -> None:
+        self.assertEqual(self._request(AnonymousUser()).status_code, 200)
+
+    def test_moderator_without_factor_is_gated(self) -> None:
+        user = self._make_user("mod1")
+        player = Players.objects.create(
+            id="modp1",
+            name="mod1",
+            url="https://example.com/mod1",
+            claim_status=Players.ClaimStatus.CLAIMED,
+            user=user,
+        )
+        game = Games.objects.create(
+            id="modg1",
+            name="Mod Game",
+            slug="mod-game",
+            release="2000-01-01",
+            boxart="https://example.com/cover.png",
+        )
+        game.moderators.add(player)
+        self.assertEqual(self._request(user).status_code, 403)
+
+    def test_allowlisted_allauth_path_passes_while_gated(self) -> None:
+        user = self._make_user("super5", is_superuser=True)
+        response = self._request(user, path="/_allauth/browser/v1/auth/session")
+        self.assertEqual(response.status_code, 200)
+
+    def test_allowlisted_accounts_path_passes_while_gated(self) -> None:
+        user = self._make_user("super9", is_superuser=True)
+        response = self._request(user, path="/accounts/oauth-login-complete/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_illiad_not_gated(self) -> None:
+        user = self._make_user("super6", is_superuser=True)
+        self.assertEqual(self._request(user, path="/illiad/").status_code, 200)
+
+    def test_gate_lifts_after_totp_created(self) -> None:
+        user = self._make_user("super7", is_superuser=True)
+        self.assertTrue(is_gated(user))
+        self._add_factor(user, Authenticator.Type.TOTP)
+        self.assertFalse(is_gated(user))
+
+    @override_settings(MFA_ENFORCE_FOR_PRIVILEGED=False)
+    def test_kill_switch_disables_enforcement(self) -> None:
+        user = self._make_user("super8", is_superuser=True)
+        self.assertEqual(self._request(user).status_code, 200)
+
+    def test_social_challenge_totp_only(self) -> None:
+        user = self._make_user("soc1")
+        self._add_factor(user, Authenticator.Type.TOTP)
+        self.assertTrue(social_login_requires_mfa(user))
+
+    def test_social_challenge_totp_and_recovery_codes(self) -> None:
+        user = self._make_user("soc2")
+        self._add_factor(user, Authenticator.Type.TOTP)
+        self._add_factor(user, Authenticator.Type.RECOVERY_CODES)
+        self.assertTrue(social_login_requires_mfa(user))
+
+    def test_social_challenge_passkey_only_exempt(self) -> None:
+        user = self._make_user("soc3")
+        self._add_factor(user, Authenticator.Type.WEBAUTHN)
+        self.assertFalse(social_login_requires_mfa(user))
+
+    def test_social_challenge_totp_and_passkey_exempt(self) -> None:
+        user = self._make_user("soc4")
+        self._add_factor(user, Authenticator.Type.TOTP)
+        self._add_factor(user, Authenticator.Type.WEBAUTHN)
+        self.assertFalse(social_login_requires_mfa(user))
+
+    def test_social_challenge_no_factor(self) -> None:
+        user = self._make_user("soc5")
+        self.assertFalse(social_login_requires_mfa(user))

--- a/backend/tests/test_runs.py
+++ b/backend/tests/test_runs.py
@@ -595,6 +595,78 @@ class RunsTimingSubmission(AuthTestBase):
         data = response.json()
         self.assertIsNotNone(data.get("id"))
 
+    def test_put_non_timing_field_not_blocked_by_preexisting_gap(
+        self,
+    ) -> None:
+        # A run already exists missing IGT (game2 requires both REALTIME and INGAME). An
+        # archiver-style PUT that only touches a non-timing field (arch_video) must not be
+        # rejected by the pre-existing timing gap it did not introduce - expect 200.
+        Runs.objects.create(
+            id="rsublegacy",
+            game=self.game2,
+            category=self.cat2,
+            runtype="main",
+            place=1,
+            url="https://example.com/run/legacy",
+            time="1:00.000",
+            time_secs=60.0,
+            timeigt_secs=None,
+        )
+
+        response = self.client.put(
+            "/rsublegacy",
+            json={
+                "arch_video": "https://www.youtube.com/watch?v=archived1",
+            },  # type: ignore
+            headers={"X-API-Key": self.api_key},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        run = Runs.objects.get(id="rsublegacy")
+        self.assertEqual(
+            run.arch_video,
+            "https://www.youtube.com/watch?v=archived1",
+        )
+        # The pre-existing gap is still recorded (non-blocking), not silently dropped.
+        self.assertTrue(run.has_import_issues)
+        self.assertTrue(
+            any(
+                issue["type"] == "missing_timing_methods"
+                and "igt" in issue["methods"]
+                for issue in run.import_issues
+            ),
+        )
+
+    def test_put_introducing_new_gap_still_rejected(
+        self,
+    ) -> None:
+        # A run with both required methods present; an edit that zeroes IGT introduces a new
+        # gap and must still be rejected - the delta-aware check only forgives PRE-existing
+        # gaps, not regressions caused by this edit. Expect 422.
+        Runs.objects.create(
+            id="rsubcomplete",
+            game=self.game2,
+            category=self.cat2,
+            runtype="main",
+            place=1,
+            url="https://example.com/run/complete",
+            time="1:00.000",
+            time_secs=60.0,
+            timeigt="0:58.000",
+            timeigt_secs=58.0,
+        )
+
+        response = self.client.put(
+            "/rsubcomplete",
+            json={
+                "timeigt_secs": 0.0,
+            },  # type: ignore
+            headers={"X-API-Key": self.api_key},
+        )
+        self.assertEqual(response.status_code, 422)
+        data = response.json()
+        self.assertEqual(data["error"], "Run timing validation failed")
+
 
 class RunSchemaTimingFields(TestCase):
 

--- a/backend/website/settings.py
+++ b/backend/website/settings.py
@@ -92,6 +92,7 @@ MIDDLEWARE = [
     "accounts.middleware.PathRateLimitMiddleware",
     "accounts.middleware.TurnstileMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "accounts.middleware.MFASetupRequiredMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "auditlog.middleware.AuditActorMiddleware",
@@ -314,6 +315,10 @@ MFA_SUPPORTED_TYPES = ["totp", "webauthn", "recovery_codes"]
 MFA_PASSKEY_LOGIN_ENABLED = True
 MFA_PASSKEY_SIGNUP_ENABLED = False
 MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = DEBUG  # WebAuthn refuses HTTP except on localhost
+
+# Require superusers and game moderators to have a TOTP authenticator or a WebAuthn passkey
+# before they can use the API (enforced by accounts.middleware.MFASetupRequiredMiddleware).
+MFA_ENFORCE_FOR_PRIVILEGED = os.getenv("MFA_ENFORCE_FOR_PRIVILEGED", "True") == "True"
 OAUTH_REAUTH_INTENT_TTL_SECONDS = int(
     os.getenv("OAUTH_REAUTH_INTENT_TTL_SECONDS", "600")
 )


### PR DESCRIPTION
### v4.1.0
###### June 2, 2026
*   Added
    *   Added time-based one-time passwords (TOTP) to the Security panel.
        *   TOTPs are required for moderators of games and super users.
            *   Using a Passkey exempts you from needing TOTP.
        *   Also added recovery code support.
    *   Added a new query option to `/players/search?` that allows you to search for specific Twitch names.
    *   Added a new `/{id}/import-issues` endpoint that allows mods to see what invalidation were raised when the run was imported from SRC.
    *   Added additional logic to remove speedruns that were deleted from SRC.
    *   Added additional checks to Celery tasks so it doesn't re-iterate the same runs over and over and over and over and over and over and over and over and over and over and over and over...

*   Fixed
    *   Fixed an issue where uploading runs from thps.run would fail when converting DateTimeFields.
    *   Fixed an issue where `vid_status` was missing from POST `/runs`
    *   Fixed an issue where POST `/runs` did not ingest `*_secs` and self-create the human-friendly form of times.
    *   Fixed an issue where Celery tasks, in some situations, would call the wrong world record from the wrong category, calculate off of that, and report a point total that was insanely high (one example had a run get 408 MILLION HOLY).
    *   Fixed an issue where PUT'ing variables to `/runs` would cause issues with validation if the run was a legacy run.