### PR TITLE
v4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+### v4.1.2
+###### June 4, 2026
+*   Added
+    *   Added a new `Resync` button in the `Danger Zone` of a user's profile settings that resyncs their username and URL from SRC.
+        *   Your unique ID never changes; but, if you change your SRC username, this will let us resync you to avoid errors.
+    *   Added the `Exclude from Streams` button to the General section of profile settings (was in Social Media).
+
+*   Changed
+    *   Changed the General profile settings around and described the different username types better (hopefully).
+    *   Changed the behavior of the gradient name selection panel to where it shows your nickname (if you have one) OR your username (was just your username).
+    *   Changed the behavior of the navbar to where it shows your nickname (if you have one) OR yoru username (was just your username) in the top-right.
+    *   Changed the filtering for `GET /streams` to where it will never show a player who has exempted themselves from streams.
+
+*   Removed
+    *   Removed the ability for users to modify their `SRC Username` (was `Display Name`).
+
+***
+
 ### v4.1.1
 ###### June 3, 2026
 *   Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # thps.run Website - Backend
-## Version 4.1.1
+## Version 4.1.2
 
 ![Django](https://img.shields.io/badge/Django-6.0-green.svg?logo=django&logoColor=white)
 ![Django Ninja](https://img.shields.io/badge/1.6-blue?color=black&label=django-ninja&logo=fastapi&logoColor=white)

--- a/backend/accounts/middleware.py
+++ b/backend/accounts/middleware.py
@@ -138,6 +138,7 @@ _PATH_RATE_LIMITS: dict[tuple[str, str], tuple[int, int]] = {
     ("POST", "/api/v1/auth/me/email/change"): (3, 3600),
     ("POST", "/api/v1/auth/me/email/resend"): (3, 3600),
     ("POST", "/api/v1/auth/register/correct-email"): (3, 3600),
+    ("POST", "/api/v1/auth/me/resync"): (5, 3600),
 }
 
 

--- a/backend/api/v1/routers/auth/me.py
+++ b/backend/api/v1/routers/auth/me.py
@@ -8,7 +8,10 @@ from django.db import transaction
 from django.http import HttpRequest
 from django.utils import timezone
 from ninja import Router, Status
+from pydantic import ValidationError
 from srl.models import CountryCodes, Players
+from srl.srcom.schema.src import SrcPlayersModel
+from srl.utils import SrcRateLimited, src_api
 
 from api.permissions import session_only
 from api.v1.schemas.auth import (
@@ -22,6 +25,7 @@ from api.v1.schemas.auth import (
     SocialsEmbed,
 )
 from api.v1.schemas.base import ErrorResponse
+from api.v1.schemas.common import sanitize_speedrun_url
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +175,7 @@ def update_me(
 
     if body.player is not None:
         player_fields = body.player.model_fields_set
-        for field in ("name", "nickname", "pronouns", "ex_stream"):
+        for field in ("nickname", "pronouns", "ex_stream"):
             if field in player_fields:
                 setattr(player, field, getattr(body.player, field))
                 player_update_fields.append(field)
@@ -349,3 +353,88 @@ def delete_me(
     )
 
     return Status(204, None)
+
+
+@router.post(
+    "/me/resync",
+    response={
+        200: PlayerProfileResponse,
+        401: ErrorResponse,
+        403: ErrorResponse,
+        502: ErrorResponse,
+        503: ErrorResponse,
+    },
+    summary="Resync Username and URL from Speedrun.com",
+    description="""\
+Re-pulls the authenticated player's name and profile URL from Speedrun.com using their player
+ID (which is their Speedrun.com user ID). No request body. Other profile fields are left
+untouched. Returns the same shape as GET /me.
+""",
+    auth=session_only("profile.edit_own"),
+)
+def resync_me(
+    request: HttpRequest,
+) -> Status:
+    player: Players = request.auth.player  # type: ignore
+
+    try:
+        src_data = src_api(
+            f"https://speedrun.com/api/v1/users/{player.id}",
+            max_retries=2,
+            backoff_secs=2,
+        )
+    except SrcRateLimited:
+        return Status(
+            503,
+            ErrorResponse(
+                error="Speedrun.com is rate-limiting requests. Please try again shortly.",
+                details=None,
+            ),
+        )
+    except ValueError:
+        return Status(
+            502,
+            ErrorResponse(
+                error="Could not fetch your profile from Speedrun.com.",
+                details=None,
+            ),
+        )
+
+    if not isinstance(src_data, dict):
+        return Status(
+            502,
+            ErrorResponse(
+                error="Unexpected response from Speedrun.com.",
+                details=None,
+            ),
+        )
+
+    try:
+        src_player = SrcPlayersModel.model_validate(src_data)
+    except ValidationError:
+        return Status(
+            502,
+            ErrorResponse(
+                error="Could not read your profile from Speedrun.com.",
+                details=None,
+            ),
+        )
+
+    new_url: str | None = sanitize_speedrun_url(src_player.weblink)
+
+    player.name = src_player.names.international
+    update_fields: list[str] = ["name"]
+
+    if new_url is not None:
+        player.url = new_url
+        update_fields.append("url")
+    else:
+        logger.warning(
+            "SRC weblink for player %s did not sanitize; keeping existing URL: %r",
+            player.id,
+            src_player.weblink,
+        )
+
+    player.save(update_fields=update_fields)
+
+    return Status(200, _build_profile_response(player))

--- a/backend/api/v1/routers/resources/streams.py
+++ b/backend/api/v1/routers/resources/streams.py
@@ -39,8 +39,10 @@ def get_live_streams(
     limit: Annotated[int, Query(ge=1, le=50, description="Max results")] = 20,
 ) -> Status:
     try:
-        queryset = NowStreaming.objects.select_related("streamer", "game").order_by(
-            "-stream_time",
+        queryset = (
+            NowStreaming.objects.select_related("streamer", "game")
+            .exclude(streamer__ex_stream=True)
+            .order_by("-stream_time")
         )
 
         if game_id:
@@ -81,6 +83,7 @@ def get_stream(
         stream = (
             NowStreaming.objects.select_related("streamer", "game")
             .filter(streamer_id=player_id)
+            .exclude(streamer__ex_stream=True)
             .first()
         )
         if not stream:

--- a/backend/api/v1/schemas/auth.py
+++ b/backend/api/v1/schemas/auth.py
@@ -183,7 +183,6 @@ HEX_COLOR_PATTERN = re.compile(r"^#[0-9A-Fa-f]{6}$")
 
 
 class PlayerUpdateEmbed(Schema):
-    name: str | None = Field(None, min_length=1, max_length=30)
     nickname: str | None = Field(None, max_length=30)
     pronouns: str | None = Field(None, max_length=50)
     country: str | None = None

--- a/backend/srl/utils.py
+++ b/backend/srl/utils.py
@@ -25,6 +25,10 @@ SRC_MAX_RETRIES = 10
 SRC_BACKOFF_SECS = 60
 
 
+class SrcRateLimited(ValueError):
+    """Raised when SRC keeps returning 420/503 until retries are exhausted."""
+
+
 def convert_time(
     secs: float,
 ) -> str:
@@ -64,23 +68,37 @@ def convert_time(
 def src_api(
     url: str,
     raw: bool = False,
+    max_retries: int | None = None,
+    backoff_secs: int | None = None,
 ) -> dict | list:
     """Processes a Speedrun.com API v1 GET request to return values from any of its endpoints.
 
-    Retries on 420 (Enhance Your Calm) and 503 (Service Unavailable) up to SRC_MAX_RETRIES
-    times with a fixed SRC_BACKOFF_SECS sleep between attempts.
+    Retries on 420 (Enhance Your Calm) and 503 (Service Unavailable) up to `max_retries`
+    times with a fixed `backoff_secs` sleep between attempts. Both default to the module
+    constants SRC_MAX_RETRIES / SRC_BACKOFF_SECS when not provided, so existing callers are
+    unaffected; request-path callers can pass small values to avoid stalling.
 
     Arguments:
         url (str): The complete URL of the API endpoint being called.
         raw (bool): If True, return the full JSON envelope (e.g., when pagination links or
             sibling fields are needed). Default unwraps and returns the "data" field.
+        max_retries (int | None): Override for the retry count. Defaults to SRC_MAX_RETRIES.
+        backoff_secs (int | None): Override for the per-attempt sleep. Defaults to
+            SRC_BACKOFF_SECS.
 
     Returns:
         dict | list: The "data" field (dict or list depending on the endpoint), or the
             full envelope when raw=True.
+
+    Raises:
+        SrcRateLimited: When 420/503 persists until retries are exhausted.
+        ValueError: When the response is otherwise non-200.
     """
+    retries: int = SRC_MAX_RETRIES if max_retries is None else max_retries
+    backoff: int = SRC_BACKOFF_SECS if backoff_secs is None else backoff_secs
+
     response = None
-    for attempt in range(1, SRC_MAX_RETRIES + 1):
+    for attempt in range(1, retries + 1):
         response = requests.get(url, headers=SRC_HEADERS, timeout=30)
         if response.status_code not in (420, 503):
             break
@@ -89,14 +107,14 @@ def src_api(
             "SRC rate limit (%s) on attempt %d/%d, sleeping %ds: %s",
             response.status_code,
             attempt,
-            SRC_MAX_RETRIES,
-            SRC_BACKOFF_SECS,
+            retries,
+            backoff,
             url,
         )
-        time.sleep(SRC_BACKOFF_SECS)
+        time.sleep(backoff)
     else:
-        raise ValueError(
-            f"SRC API rate limit exceeded after {SRC_MAX_RETRIES} retries ({url})"
+        raise SrcRateLimited(
+            f"SRC API rate limit exceeded after {retries} retries ({url})"
         )
 
     if response.status_code != 200:


### PR DESCRIPTION
### v4.1.2
###### June 4, 2026
*   Added
    *   Added a new `Resync` button in the `Danger Zone` of a user's profile settings that resyncs their username and URL from SRC.
        *   Your unique ID never changes; but, if you change your SRC username, this will let us resync you to avoid errors.
    *   Added the `Exclude from Streams` button to the General section of profile settings (was in Social Media).

*   Changed
    *   Changed the General profile settings around and described the different username types better (hopefully).
    *   Changed the behavior of the gradient name selection panel to where it shows your nickname (if you have one) OR your username (was just your username).
    *   Changed the behavior of the navbar to where it shows your nickname (if you have one) OR yoru username (was just your username) in the top-right.
    *   Changed the filtering for `GET /streams` to where it will never show a player who has exempted themselves from streams.

*   Removed
    *   Removed the ability for users to modify their `SRC Username` (was `Display Name`).