### PR TITLE
v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### v4.2.1
+###### June 7, 2026
+*   Added
+    *   Added the `repair_missing_il_levels` management command to fix an issue where there were IL speedruns without a category or level associated.
+        *   This was from a rare bug with the v3.X build that I never got around to fixing. The bug was fixed, but these runs were still messed up. Now, they are good!
+
+*   Fixed
+    *   Fixed an issue where two specific false positives could be sent to Sentry.
+        *   The Celery agents can be recyled via `EX_RECYCLE`, but it would be seen as an error; now, it is seen as a healthy part of the code.
+        *   `SIGABRT`/`SystemExit` could be caused by a gunicorn, but the logging integration would incorrectly think that the worker was killed when it was instead idle. Now, they are dropped.
+
+***
+
 ### v4.2
 ###### June 6, 2026
 *   Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # thps.run Website - Backend
-## Version 4.1.2
+## Version 4.2.1
 
 ![Django](https://img.shields.io/badge/Django-6.0-green.svg?logo=django&logoColor=white)
 ![Django Ninja](https://img.shields.io/badge/1.6-blue?color=black&label=django-ninja&logo=fastapi&logoColor=white)

--- a/backend/srl/leaderboard/recalculation.py
+++ b/backend/srl/leaderboard/recalculation.py
@@ -1,6 +1,7 @@
 import bisect
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Iterator
 
 from auditlog.models import GameAuditEvent
 from auditlog.recorders import record_event
@@ -15,6 +16,7 @@ from srl.models import (
     Players,
     RunHistory,
     Runs,
+    RunVariableValues,
     Variables,
     VariableValues,
 )
@@ -609,6 +611,62 @@ def _handle_remove(
                 event_date,
                 formula_points,
             )
+
+
+def enumerate_leaderboard_variants(
+    base_query: QuerySet[Runs],
+) -> Iterator[dict]:
+    """Yield each distinct leaderboard variant found within a base run queryset.
+
+    Groups the runs by (game_id, category_id, level_id, runtype), then within each group yields one
+    dict per distinct variable-value signature.
+
+    Arguments:
+        base_query (QuerySet[Runs]): The runs to enumerate variants from (caller
+            applies vid_status / game / etc. filters).
+
+    Yields:
+        leaderboard (dict): {game_id, category_id, level_id, runtype,
+            variable_value_map}.
+    """
+    groups = base_query.values(
+        "game_id",
+        "category_id",
+        "level_id",
+        "runtype",
+    ).distinct()
+
+    for group in groups:
+        group_qs = base_query.filter(**group)
+        group_run_ids = group_qs.values_list("id", flat=True)
+
+        rvv_qs = RunVariableValues.objects.filter(run_id__in=group_run_ids).values(
+            "run_id",
+            "variable_id",
+            "value_id",
+        )
+
+        run_signatures: dict[str, frozenset] = {}
+        for rvv in rvv_qs:
+            run_id = rvv["run_id"]
+            if run_id not in run_signatures:
+                run_signatures[run_id] = frozenset()
+            run_signatures[run_id] = run_signatures[run_id] | frozenset(
+                [(rvv["variable_id"], rvv["value_id"])],
+            )
+
+        for run_id in group_run_ids:
+            if run_id not in run_signatures:
+                run_signatures[run_id] = frozenset()
+
+        seen_sigs: set[frozenset] = set()
+        for signature in run_signatures.values():
+            if signature not in seen_sigs:
+                seen_sigs.add(signature)
+                yield {
+                    **group,
+                    "variable_value_map": dict(signature),
+                }
 
 
 def get_runs_for_leaderboard(

--- a/backend/srl/management/commands/build_run_history.py
+++ b/backend/srl/management/commands/build_run_history.py
@@ -10,13 +10,13 @@ from django.db import transaction
 
 from srl.leaderboard.recalculation import (
     build_leaderboard_metadata,
+    enumerate_leaderboard_variants,
     process_leaderboard,
 )
 from srl.models import (
     Games,
     RunHistory,
     Runs,
-    RunVariableValues,
 )
 
 
@@ -47,11 +47,7 @@ class Command(BaseCommand):
         self,
         game_filter: str | None,
     ) -> Iterator[dict]:
-        """Enumerate all distinct leaderboard variants.
-
-        Groups runs by (game_id, category_id, level_id, runtype), then within each
-        group finds all distinct variable-value combinations via RunVariableValues.
-        """
+        """Enumerate all distinct leaderboard variants (optionally one game)."""
         base_query = Runs.objects.filter(
             vid_status="verified",
         ).exclude(
@@ -62,43 +58,7 @@ class Command(BaseCommand):
         if game_filter:
             base_query = base_query.filter(game_id=game_filter)
 
-        groups = base_query.values(
-            "game_id",
-            "category_id",
-            "level_id",
-            "runtype",
-        ).distinct()
-
-        for group in groups:
-            group_qs = base_query.filter(**group)
-            group_run_ids = group_qs.values_list("id", flat=True)
-
-            rvv_qs = RunVariableValues.objects.filter(run_id__in=group_run_ids).values(
-                "run_id", "variable_id", "value_id"
-            )
-
-            # Build a map of run_id -> frozenset of (var_id, val_id) pairs
-            run_signatures: dict[str, frozenset] = {}
-            for rvv in rvv_qs:
-                run_id = rvv["run_id"]
-                if run_id not in run_signatures:
-                    run_signatures[run_id] = frozenset()
-                run_signatures[run_id] = run_signatures[run_id] | frozenset(
-                    [(rvv["variable_id"], rvv["value_id"])]
-                )
-
-            for run_id in group_run_ids:
-                if run_id not in run_signatures:
-                    run_signatures[run_id] = frozenset()
-
-            seen_sigs: set[frozenset] = set()
-            for signature in run_signatures.values():
-                if signature not in seen_sigs:
-                    seen_sigs.add(signature)
-                    yield {
-                        **group,
-                        "variable_value_map": dict(signature),
-                    }
+        return enumerate_leaderboard_variants(base_query)
 
     def handle(
         self,

--- a/backend/srl/management/commands/repair_missing_il_levels.py
+++ b/backend/srl/management/commands/repair_missing_il_levels.py
@@ -1,0 +1,285 @@
+import argparse
+from typing import Any
+
+from api.signals import disable_history_signals
+from api.v1.routers.utils.cache_utils import _HISTORY_CACHE_PREFIX
+from django.core.cache import caches
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from srl.leaderboard.recalculation import (
+    build_leaderboard_metadata,
+    clear_leaderboard_history,
+    enumerate_leaderboard_variants,
+    process_leaderboard,
+)
+from srl.models import Categories, Levels, Runs
+from srl.srcom.categories import sync_categories
+from srl.srcom.levels import sync_levels
+from srl.utils import src_api_probe
+
+
+class Command(BaseCommand):
+    """Repair IL runs missing their level (and category) FK, then rebuild history."""
+
+    help = (
+        "Find IL runs with no level, restore their category + level from the SRC "
+        "API, then rebuild RunHistory for the affected leaderboard variants."
+    )
+
+    def add_arguments(
+        self,
+        parser: argparse.ArgumentParser,
+    ) -> None:
+        """Register CLI options."""
+        parser.add_argument(
+            "--game",
+            type=str,
+            help="Limit to a game slug (e.g. thps34). Default: all games.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report intended changes; write nothing.",
+        )
+        parser.add_argument(
+            "--no-history",
+            action="store_true",
+            help="Fix runs only; skip the RunHistory rebuild.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Cap the number of runs processed (testing / incremental).",
+        )
+
+    def handle(
+        self,
+        *args: Any,
+        **options: Any,
+    ) -> None:
+        """Repair FKs for level-less IL runs and rebuild affected history."""
+        game_slug = options.get("game")
+        dry_run = options.get("dry_run", False)
+        no_history = options.get("no_history", False)
+        limit = options.get("limit")
+
+        qs = Runs.objects.filter(runtype="il", level__isnull=True).order_by("id")
+        if game_slug:
+            qs = qs.filter(game__slug=game_slug)
+        if limit:
+            qs = qs[:limit]
+
+        targets = list(qs)
+        self.stdout.write(f"Found {len(targets)} IL run(s) with no level assigned.")
+
+        repaired: list[Runs] = []
+        counts = {
+            "repaired": 0,
+            "missing_on_src": 0,
+            "no_level_on_src": 0,
+            "sync_failed": 0,
+            "fetch_error": 0,
+        }
+
+        for run in targets:
+            try:
+                status, payload = src_api_probe(
+                    f"https://speedrun.com/api/v1/runs/{run.id}",
+                )
+            except Exception as exc:
+                counts["fetch_error"] += 1
+                self.stdout.write(
+                    self.style.ERROR(f"  {run.id}: SRC fetch error: {exc}"),
+                )
+                continue
+
+            if status == 404:
+                counts["missing_on_src"] += 1
+                self.stdout.write(
+                    self.style.WARNING(f"  {run.id}: not found on SRC (404), skipped."),
+                )
+                continue
+
+            data = (payload or {}).get("data") if isinstance(payload, dict) else None
+            if status != 200 or not data:
+                counts["fetch_error"] += 1
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"  {run.id}: unexpected SRC response (HTTP {status}), skipped.",
+                    ),
+                )
+                continue
+
+            level_id = data.get("level")
+            category_id = data.get("category")
+
+            if not level_id:
+                counts["no_level_on_src"] += 1
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  {run.id}: SRC reports no level "
+                        f"(full-game mistyped as IL?), skipped.",
+                    ),
+                )
+                continue
+
+            if not self._ensure_category(category_id, run.id):
+                counts["sync_failed"] += 1
+                continue
+            if not self._ensure_level(level_id, run.id):
+                counts["sync_failed"] += 1
+                continue
+
+            run.category_id = category_id
+            run.level_id = level_id
+            repaired.append(run)
+            counts["repaired"] += 1
+            self.stdout.write(f"  {run.id}: category={category_id}, level={level_id}")
+
+        if repaired and not dry_run:
+            Runs.objects.bulk_update(
+                repaired,
+                ["category_id", "level_id"],
+                batch_size=200,
+            )
+            self.stdout.write(self.style.SUCCESS(f"Updated {len(repaired)} run(s)."))
+        elif dry_run:
+            self.stdout.write(self.style.NOTICE("DRY RUN: no FK changes written."))
+
+        self.stdout.write(
+            f"Repaired={counts['repaired']} "
+            f"missing_on_src={counts['missing_on_src']} "
+            f"no_level_on_src={counts['no_level_on_src']} "
+            f"sync_failed={counts['sync_failed']} "
+            f"fetch_error={counts['fetch_error']}",
+        )
+
+        if no_history:
+            self.stdout.write(
+                self.style.NOTICE("--no-history: skipping RunHistory rebuild."),
+            )
+            return
+        if not repaired:
+            self.stdout.write("No runs repaired; nothing to rebuild.")
+            return
+
+        self._rebuild_history(repaired, dry_run)
+
+    def _ensure_category(
+        self,
+        category_id: str | None,
+        run_id: str,
+    ) -> bool:
+        """Make sure the category exists locally; sync on demand. Returns success."""
+        if not category_id:
+            self.stdout.write(
+                self.style.ERROR(f"  {run_id}: SRC payload has no category, skipped."),
+            )
+            return False
+        if Categories.objects.filter(id=category_id).exists():
+            return True
+        try:
+            sync_categories(category_id)
+        except Exception as exc:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"  {run_id}: sync_categories({category_id}) failed: {exc}",
+                ),
+            )
+            return False
+        return Categories.objects.filter(id=category_id).exists()
+
+    def _ensure_level(
+        self,
+        level_id: str,
+        run_id: str,
+    ) -> bool:
+        """Make sure the level exists locally; sync on demand. Returns success."""
+        if Levels.objects.filter(id=level_id).exists():
+            return True
+        try:
+            sync_levels(level_id)
+        except Exception as exc:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"  {run_id}: sync_levels({level_id}) failed: {exc}",
+                ),
+            )
+            return False
+        return Levels.objects.filter(id=level_id).exists()
+
+    def _rebuild_history(
+        self,
+        repaired: list[Runs],
+        dry_run: bool,
+    ) -> None:
+        """Rebuild RunHistory for only the leaderboard variants that changed."""
+        affected_keys = {(r.game_id, r.category_id, r.level_id) for r in repaired}
+        game_ids = {g for (g, _c, _l) in affected_keys}
+        cat_ids = {c for (_g, c, _l) in affected_keys}
+        level_ids = {lv for (_g, _c, lv) in affected_keys}
+
+        base_query = Runs.objects.filter(
+            vid_status="verified",
+            runtype="il",
+            game_id__in=game_ids,
+            category_id__in=cat_ids,
+            level_id__in=level_ids,
+        ).exclude(
+            v_date__isnull=True,
+            date__isnull=True,
+        )
+
+        variants = [
+            v
+            for v in enumerate_leaderboard_variants(base_query)
+            if (v["game_id"], v["category_id"], v["level_id"]) in affected_keys
+        ]
+        self.stdout.write(
+            f"Rebuilding history for {len(variants)} affected variant(s).",
+        )
+        if not variants:
+            return
+
+        _, game_is_ce, *_ = build_leaderboard_metadata(variants)
+
+        total_entries = 0
+        with disable_history_signals():
+            for variant in variants:
+                with transaction.atomic():
+                    if not dry_run:
+                        clear_leaderboard_history(variant)
+                    entries, _runs, _pts = process_leaderboard(
+                        variant,
+                        dry_run=dry_run,
+                        game_is_ce=game_is_ce,
+                    )
+                    total_entries += entries
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"History rebuild: {total_entries} entries across "
+                f"{len(variants)} variant(s).",
+            ),
+        )
+
+        if not dry_run:
+            self._purge_history_cache()
+
+    def _purge_history_cache(
+        self,
+    ) -> None:
+        """Invalidate the pointslb history cache namespace."""
+        cache = caches["default"]
+        if hasattr(cache, "delete_pattern"):
+            cache.delete_pattern(f"{_HISTORY_CACHE_PREFIX}:*")
+            self.stdout.write(self.style.SUCCESS("Historical cache cleared."))
+        else:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Cache backend lacks delete_pattern - history caches may be "
+                    "stale until cleared manually.",
+                ),
+            )

--- a/backend/website/observability.py
+++ b/backend/website/observability.py
@@ -1,4 +1,5 @@
 import sentry_sdk
+from billiard.pool import EX_RECYCLE
 from celery.signals import task_failure, worker_process_shutdown
 
 
@@ -23,7 +24,7 @@ def on_worker_process_shutdown(
     **kwargs,
 ) -> None:
     """Report abnormal worker child exits (OOM/SIGKILL/time-limit) to Sentry."""
-    if exitcode not in (0, None):
+    if exitcode not in (0, None, EX_RECYCLE):
         sentry_sdk.capture_message(
             f"Celery worker child {pid} exited abnormally: exitcode={exitcode}",
             level="error",

--- a/backend/website/settings.py
+++ b/backend/website/settings.py
@@ -22,11 +22,41 @@ def _require_env(
     return value
 
 
+def _sentry_before_send(
+    event: dict,
+    hint: dict,
+) -> dict | None:
+    """Drop gunicorn worker-abort noise before it reaches Sentry.
+
+    This is mainly used to extend the types of errors that could be brought from Celery agents
+    before they are sent to Sentry.io or wherever. The current implementation removes any
+    `SIGABRT`/`SystermExit` errors that are generated when Gunicorn's arbiter kills the agent.
+    Without this, it would just be noise sent to Sentry.
+
+    Arguments:
+        event (dict): The Sentry event about to be sent.
+        hint (dict): Sentry's hint, which carries exc_info for exception events.
+
+    Returns:
+        result (dict | None): The event to send, or None to drop it.
+    """
+    exc_info: tuple | None = hint.get("exc_info")
+    exc_type: type | None = exc_info[0] if exc_info else None
+    if exc_type is not None and issubclass(exc_type, SystemExit):
+        return None
+
+    for value in (event.get("exception") or {}).get("values") or []:
+        if value.get("type") == "SystemExit":
+            return None
+    return event
+
+
 if os.getenv("SENTRY_ENABLED") == "True":
     sentry_sdk.init(
         dsn=os.getenv("SENTRY_DSN"),
         send_default_pii=False,
         traces_sample_rate=0.5,
+        before_send=_sentry_before_send,
     )
 
 SECRET_KEY = _require_env("SECRET_KEY")
@@ -235,9 +265,9 @@ CELERY_RESULT_EXTENDED = True
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_TASK_TRACK_STARTED = True
 CELERY_TASK_TIME_LIMIT = 30 * 60
-CELERY_TASK_SOFT_TIME_LIMIT = 20 * 60  # catchable SoftTimeLimitExceeded before the hard SIGKILL
-CELERY_WORKER_MAX_MEMORY_PER_CHILD = 350000  # KB (~350 MB); recycle child gracefully before OOM
-CELERY_WORKER_PREFETCH_MULTIPLIER = 1  # a crash drops at most one message, not a prefetched batch
+CELERY_TASK_SOFT_TIME_LIMIT = 20 * 60
+CELERY_WORKER_MAX_MEMORY_PER_CHILD = 350000
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
 # CELERY BEAT SCHEDULE
 CELERY_BEAT_SCHEDULE = {
@@ -397,7 +427,7 @@ HEADLESS_FRONTEND_URLS = {
     "socialaccount_login_error": f"{FRONTEND_URL}/login/error/",
 }
 
-# EMAIL (Resend via django-anymail TODO:)
+# EMAIL (Resend via django-anymail)
 EMAIL_BACKEND = "anymail.backends.resend.EmailBackend"
 ANYMAIL = {
     "RESEND_API_KEY": os.getenv("RESEND_API_KEY", ""),


### PR DESCRIPTION
###### June 7, 2026
*   Added
    *   Added the `repair_missing_il_levels` management command to fix an issue where there were IL speedruns without a category or level associated.
        *   This was from a rare bug with the v3.X build that I never got around to fixing. The bug was fixed, but these runs were still messed up. Now, they are good!

*   Fixed
    *   Fixed an issue where two specific false positives could be sent to Sentry.
        *   The Celery agents can be recyled via `EX_RECYCLE`, but it would be seen as an error; now, it is seen as a healthy part of the code.
        *   `SIGABRT`/`SystemExit` could be caused by a gunicorn, but the logging integration would incorrectly think that the worker was killed when it was instead idle. Now, they are dropped.