### PR TITLE
v4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### v4.2.2
+###### June 8, 2026
+*   Fixed an issue where the client IP resolver was incorrectly accounting for the wrong IPs from `X-Forwarded-For`.
+    *   The fix hardens how IPs are given to thps.run; before, it was reading from left-to-right on the IP chain and not right-to-left due to proxying.
+
+***
+
 ### v4.2.1
 ###### June 7, 2026
 *   Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # thps.run Website - Backend
-## Version 4.2.1
+## Version 4.2.2
 
 ![Django](https://img.shields.io/badge/Django-6.0-green.svg?logo=django&logoColor=white)
 ![Django Ninja](https://img.shields.io/badge/1.6-blue?color=black&label=django-ninja&logo=fastapi&logoColor=white)

--- a/backend/api/client_ip.py
+++ b/backend/api/client_ip.py
@@ -48,6 +48,16 @@ def _is_trusted(
 def client_ip(
     request: HttpRequest,
 ) -> str:
+    """Resolve the real client IP, trusting X-Forwarded-For only behind a trusted proxy.
+
+    Arguments:
+        request (HttpRequest): The incoming request.
+
+    Returns:
+        ip (str): The resolved client IP, or REMOTE_ADDR ("unknown" if absent) when the
+            peer is untrusted, no proxies are configured, or the chain yields no
+            non-proxy address.
+    """
     remote: str = request.META.get("REMOTE_ADDR", "") or "unknown"
 
     if settings.DEBUG:
@@ -66,9 +76,20 @@ def client_ip(
         return remote
 
     xff: str = request.META.get("HTTP_X_FORWARDED_FOR", "")
-    if xff:
-        first = xff.split(",")[0].strip()
-        if first:
-            return first
+    if not xff:
+        return remote
+
+    # Walks right-to-left, peeling off any trusted proxies. This is mainly to figure out what the
+    # real client IP is to prevent forged IP addresses from targeing the site.
+    for entry in reversed(xff.split(",")):
+        candidate = entry.strip()
+        if not candidate:
+            continue
+        try:
+            candidate_addr = ip_address(candidate)
+        except ValueError:
+            continue
+        if not _is_trusted(candidate_addr, proxies):
+            return candidate
 
     return remote

--- a/backend/tests/test_client_ip.py
+++ b/backend/tests/test_client_ip.py
@@ -1,0 +1,108 @@
+from api.client_ip import _get_trusted_proxies, client_ip
+from django.test import RequestFactory, TestCase, override_settings
+
+
+@override_settings(DEBUG=False, TRUSTED_PROXIES="172.18.0.0/16")
+class ClientIpTests(TestCase):
+    """Resolution of the real client IP from REMOTE_ADDR and X-Forwarded-For."""
+
+    def setUp(
+        self,
+    ) -> None:
+        """Reset the cached trusted-proxy parse and build a request factory."""
+        _get_trusted_proxies.cache_clear()
+        self.factory = RequestFactory()
+
+    def tearDown(
+        self,
+    ) -> None:
+        """Clear the cache so an overridden TRUSTED_PROXIES never leaks to other tests."""
+        _get_trusted_proxies.cache_clear()
+
+    def test_ignores_client_forged_left_most_forwarded_for_entry(
+        self,
+    ) -> None:
+        """A forged left-most XFF entry must lose to the proxy-appended real client IP."""
+        request = self.factory.get(
+            "/api/v1/runs",
+            REMOTE_ADDR="172.18.0.5",
+            HTTP_X_FORWARDED_FOR="9.9.9.9, 203.0.113.7",
+        )
+
+        self.assertEqual(client_ip(request), "203.0.113.7")
+
+    def test_returns_single_forwarded_for_entry_from_trusted_proxy(
+        self,
+    ) -> None:
+        """With one proxy hop the lone XFF entry is the client and is returned as-is."""
+        request = self.factory.get(
+            "/api/v1/runs",
+            REMOTE_ADDR="172.18.0.5",
+            HTTP_X_FORWARDED_FOR="203.0.113.7",
+        )
+
+        self.assertEqual(client_ip(request), "203.0.113.7")
+
+    def test_skips_unparseable_forged_forwarded_for_entries(
+        self,
+    ) -> None:
+        """Junk forged entries fail to parse and are skipped, not returned."""
+        request = self.factory.get(
+            "/api/v1/runs",
+            REMOTE_ADDR="172.18.0.5",
+            HTTP_X_FORWARDED_FOR="not-an-ip, 203.0.113.7",
+        )
+
+        self.assertEqual(client_ip(request), "203.0.113.7")
+
+    def test_peels_off_a_second_trusted_proxy_hop(
+        self,
+    ) -> None:
+        """Chained trusted proxies are skipped to reach the real downstream client."""
+        with override_settings(TRUSTED_PROXIES="172.18.0.0/16,10.0.0.0/8"):
+            _get_trusted_proxies.cache_clear()
+            request = self.factory.get(
+                "/api/v1/runs",
+                REMOTE_ADDR="172.18.0.5",
+                HTTP_X_FORWARDED_FOR="203.0.113.7, 10.0.0.2",
+            )
+
+            self.assertEqual(client_ip(request), "203.0.113.7")
+
+    def test_untrusted_remote_addr_ignores_forwarded_for(
+        self,
+    ) -> None:
+        """A direct (untrusted) peer is returned verbatim; its XFF is not believed."""
+        request = self.factory.get(
+            "/api/v1/runs",
+            REMOTE_ADDR="203.0.113.9",
+            HTTP_X_FORWARDED_FOR="9.9.9.9",
+        )
+
+        self.assertEqual(client_ip(request), "203.0.113.9")
+
+    def test_falls_back_to_remote_addr_when_chain_is_all_trusted(
+        self,
+    ) -> None:
+        """If every XFF entry is a trusted proxy, fall back to REMOTE_ADDR."""
+        request = self.factory.get(
+            "/api/v1/runs",
+            REMOTE_ADDR="172.18.0.5",
+            HTTP_X_FORWARDED_FOR="172.18.0.9",
+        )
+
+        self.assertEqual(client_ip(request), "172.18.0.5")
+
+    def test_no_trusted_proxies_configured_returns_remote_addr(
+        self,
+    ) -> None:
+        """With no proxies configured, X-Forwarded-For is ignored entirely."""
+        with override_settings(TRUSTED_PROXIES=""):
+            _get_trusted_proxies.cache_clear()
+            request = self.factory.get(
+                "/api/v1/runs",
+                REMOTE_ADDR="172.18.0.5",
+                HTTP_X_FORWARDED_FOR="203.0.113.7",
+            )
+
+            self.assertEqual(client_ip(request), "172.18.0.5")

--- a/docker-compose.PROD.yml
+++ b/docker-compose.PROD.yml
@@ -30,8 +30,8 @@ services:
       args:
         UID: 1000
         GID: 1000
-    ports:
-      - "8001:8001"
+    expose:
+      - "8001"
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
###### June 8, 2026
*   Fixed an issue where the client IP resolver was incorrectly accounting for the wrong IPs from `X-Forwarded-For`.
    *   The fix hardens how IPs are given to thps.run; before, it was reading from left-to-right on the IP chain and not right-to-left due to proxying.
