### PR TITLE
v4.4.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,4 +78,4 @@ SRC_BOT_MAILBOX_USER="<BOTMAIL>"
 SRC_BOT_MAILBOX_APP_PASSWORD="<BOTMAILPASS>"
 # Tune these only if SRC's email format differs from the defaults:
 SRC_2FA_SENDER_EMAIL="noreply@speedrun.com"
-SRC_2FA_SUBJECT_PATTERN="Speedrun(\.com)? login code"
+SRC_2FA_SUBJECT_PATTERN="Speedrun.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v4.4.2
+###### August 9, 2026
+*   Updated the `auth/submissions.py` to accept the user's SRC API Key (if given). THPSBot will no longer submit on their behalf.
+    *   Before, if you weren't a mod for the game, the site would try to submit through the V2 API. Removing the `players` key from the request fixes it for V1.
+*   Updated the `.env.example` file since SRC likes to keep changing the email titles of their 2FAs.
+***
+
+
 ### v4.4.1
 ###### August 7, 2026
 *   Updated libraries and backend to Django 6.0.8.

--- a/backend/api/v1/routers/auth/submissions.py
+++ b/backend/api/v1/routers/auth/submissions.py
@@ -152,15 +152,18 @@ def _build_src_run_payload(
     if body.date:
         run_data["date"] = body.date
 
-    for player in body.players:
-        if player.rel == "user":
-            run_data["players"].append(
-                {"rel": "user", "id": player.id},
-            )
-        else:
-            run_data["players"].append(
-                {"rel": "guest", "name": player.name},
-            )
+    if len(body.players) > 1:
+        for player in body.players:
+            if player.rel == "user":
+                run_data["players"].append(
+                    {"rel": "user", "id": player.id},
+                )
+            else:
+                run_data["players"].append(
+                    {"rel": "guest", "name": player.name},
+                )
+    else:
+        run_data.pop("players")
 
     if "realtime" in time_secs:
         run_data["times"]["realtime"] = time_secs["realtime"]

--- a/backend/srl/srcom/v2/client.py
+++ b/backend/srl/srcom/v2/client.py
@@ -25,8 +25,6 @@ class SrcV2Error(Exception):
 class SrcV2AuthError(SrcV2Error):
     """401 Unauthorized: stale PHPSESSID. Refresh + retry is appropriate."""
 
-    pass
-
 
 class SrcV2PermissionError(SrcV2Error):
     """403 Forbidden: account lacks moderator status on this game.
@@ -35,8 +33,6 @@ class SrcV2PermissionError(SrcV2Error):
     should fail terminally and surface to admins (likely the bot has
     been removed as a moderator on the run's game).
     """
-
-    pass
 
 
 class SrcV2RateLimited(SrcV2Error):


### PR DESCRIPTION
###### August 9, 2026
*   Updated the `auth/submissions.py` to accept the user's SRC API Key (if given). THPSBot will no longer submit on their behalf.
    *   Before, if you weren't a mod for the game, the site would try to submit through the V2 API. Removing the `players` key from the request fixes it for V1.
*   Updated the `.env.example` file since SRC likes to keep changing the email titles of their 2FAs.