### PR TITLE
v4.4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v4.4.2.1
+###### August 9, 2026
+*   Updated `/api/v1/website/main`'s `latest_wrs` embed so it provides the 5 latest world records in the last 90 days, up from 30.
+***
+
 ### v4.4.2
 ###### August 9, 2026
 *   Updated the `auth/submissions.py` to accept the user's SRC API Key (if given). THPSBot will no longer submit on their behalf.

--- a/backend/api/v1/routers/utils/query_utils.py
+++ b/backend/api/v1/routers/utils/query_utils.py
@@ -348,7 +348,7 @@ def query_latest_runs(
     else:
         filters["place__gt"] = 1
 
-    time_delta = timezone.now() - timezone.timedelta(days=30)
+    time_delta = timezone.now() - timezone.timedelta(days=90)
     runs: QuerySet[Runs] = (
         Runs.objects.select_related("game", "category", "level")
         .prefetch_related(


### PR DESCRIPTION
### v4.4.2.1
###### August 9, 2026
*   Updated `/api/v1/website/main`'s `latest_wrs` embed so it provides the 5 latest world records in the last 90 days, up from 30.