### PR TITLE
v4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### v4.4.3
+###### August 11, 2026
+*   Fixed an issue where the Celery agents would fail to create a backup of the runner's data, since they were never given full access to the `MEDIA_ROOT` folder it would be housed in.
+*   Fixed an issue where `v_date` was being used on when it attained a time instead of `date`, resulting in instances where some runs had no `v_date`, were backfilled improperly, and corrupted `RunHistory`. [#135](https://github.com/thpsrun/backend/issues/135)
+*   Fixed an issue where the `run_leaderboard_recompute` function could strip world records of their streaks and points in rare circumstances.
+    *   It's always THPS3 5th Gen...
+*   Fixed some more `N+1` errors.
+***
+
 ### v4.4.2.1
 ###### August 9, 2026
 *   Updated `/api/v1/website/main`'s `latest_wrs` embed so it provides the 5 latest world records in the last 90 days, up from 30.

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone as dt_tz
 from typing import Any
@@ -543,14 +544,29 @@ def invalidate_history_on_gradient(sender, instance, **kwargs) -> None:
 
 
 @contextlib.contextmanager
-def disable_history_signals():
-    post_save.disconnect(on_runhistory_saved, sender=RunHistory)
-    post_delete.disconnect(on_runhistory_deleted, sender=RunHistory)
+def disable_history_signals() -> Generator[None]:
+    """Temporarily disconnect the RunHistory cache-invalidation signals."""
+    post_save.disconnect(
+        sender=RunHistory,
+        dispatch_uid="api.signals.on_runhistory_saved",
+    )
+    post_delete.disconnect(
+        sender=RunHistory,
+        dispatch_uid="api.signals.on_runhistory_deleted",
+    )
     try:
         yield
     finally:
-        post_save.connect(on_runhistory_saved, sender=RunHistory)
-        post_delete.connect(on_runhistory_deleted, sender=RunHistory)
+        post_save.connect(
+            on_runhistory_saved,
+            sender=RunHistory,
+            dispatch_uid="api.signals.on_runhistory_saved",
+        )
+        post_delete.connect(
+            on_runhistory_deleted,
+            sender=RunHistory,
+            dispatch_uid="api.signals.on_runhistory_deleted",
+        )
 
 
 def _check_dirty(

--- a/backend/api/v1/routers/utils/query_utils.py
+++ b/backend/api/v1/routers/utils/query_utils.py
@@ -983,6 +983,9 @@ def query_wr_history(
             run__vid_status="verified",
             points__gte=max_points,
         )
+        .exclude(
+            end_date=F("start_date"),
+        )
         .select_related(
             "run__game",
             "run__category",

--- a/backend/srl/leaderboard/recalculation.py
+++ b/backend/srl/leaderboard/recalculation.py
@@ -1,7 +1,7 @@
 import bisect
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Iterator
 
 from auditlog.models import GameAuditEvent
 from auditlog.recorders import record_event
@@ -643,8 +643,9 @@ def get_runs_for_leaderboard(
         date__isnull=True,
     )
     base_qs = filter_by_variable_map(base_qs, leaderboard["variable_value_map"])
+
     return base_qs.annotate(
-        effective_date=Coalesce(F("v_date"), F("date")),
+        effective_date=Coalesce(F("date"), F("v_date")),
     ).order_by("effective_date")
 
 

--- a/backend/srl/leaderboard/recompute.py
+++ b/backend/srl/leaderboard/recompute.py
@@ -1,5 +1,9 @@
+from api.signals import disable_history_signals
+from api.v1.routers.utils.cache_utils import _HISTORY_CACHE_PREFIX
+from django.core.cache import caches
 from django.db import transaction
 from django_redis import get_redis_connection
+
 from srl.leaderboard.recalculation import (
     build_leaderboard_metadata,
     clear_leaderboard_history,
@@ -8,18 +12,33 @@ from srl.leaderboard.recalculation import (
 from srl.tasks._common import RECALC_LOCK_TTL_SECONDS, recalc_lock_key
 
 
+def _purge_history_cache_for_scopes(
+    scopes: list,
+) -> None:
+    """Best-effort invalidate the pointslb history cache for the given scopes."""
+
+    cache = caches["default"]
+    delete_pattern = getattr(cache, "delete_pattern", None)
+    if delete_pattern is None:
+        return
+    for scope in scopes:
+        delete_pattern(f"{_HISTORY_CACHE_PREFIX}:{scope}:*")
+
+
 def run_leaderboard_recompute(
     leaderboard_dict: dict,
 ) -> None:
-    """Clear and rebuild a single leaderboard variant's history and points.
+    """Clear and rebuild a single leaderboard variant's history and points."""
+    from srl.leaderboard.streaks import apply_streaks_to_leaderboard
 
-    The lock-free core shared by the Celery task and the synchronous verify path. Callers are
-    responsible for holding the per-variant recalc lock (see `recompute_variant_locked`).
-    """
     game_is_ce = build_leaderboard_metadata([leaderboard_dict])
+    scopes = ["all", leaderboard_dict["game_id"]]
     with transaction.atomic():
-        clear_leaderboard_history(leaderboard_dict)
-        process_leaderboard(leaderboard_dict, dry_run=False, game_is_ce=game_is_ce)
+        with disable_history_signals():
+            clear_leaderboard_history(leaderboard_dict)
+            process_leaderboard(leaderboard_dict, dry_run=False, game_is_ce=game_is_ce)
+            apply_streaks_to_leaderboard(leaderboard_dict)
+        transaction.on_commit(lambda: _purge_history_cache_for_scopes(scopes))
 
 
 def recompute_variant_locked(

--- a/backend/srl/management/commands/backfill_obsoleted_at.py
+++ b/backend/srl/management/commands/backfill_obsoleted_at.py
@@ -1,15 +1,15 @@
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from django.db.models import Max, Q
 
-from srl.models import RunHistoryEndReason, Runs
+from srl.models import RunPlayers, Runs
+from srl.srcom.leaderboards import _resolve_obsoleted_at_for_player
 
 
 class Command(BaseCommand):
     help = (
-        "Backfill Runs.obsoleted_at from the latest closed RunHistory entry "
-        "with end_reason=OBSOLETED. Idempotent. Runs with no qualifying "
-        "RunHistory entry remain NULL (treated as obsolete-since-forever)."
+        "Populate Runs.obsoleted_at for every obsolete run from achievement-date "
+        "chronology: an obsolete run is stamped with the date its own player's next "
+        "faster run was achieved."
     )
 
     def add_arguments(
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Compute backfill values but do not persist.",
+            help="Compute backfill values but roll back without persisting.",
         )
 
     def handle(
@@ -28,32 +28,37 @@ class Command(BaseCommand):
         **options,
     ) -> None:
         dry_run: bool = options["dry_run"]
-        prefix = "DRY RUN: " if dry_run else ""
+        prefix = "DRY RUN:" if dry_run else ""
 
-        candidates = (
-            Runs.objects
-            .filter(obsolete=True, obsoleted_at__isnull=True)
-            .annotate(
-                latest_obsoleted_close=Max(
-                    "history__end_date",
-                    filter=Q(history__end_reason=RunHistoryEndReason.OBSOLETED),
-                ),
-            )
-            .filter(latest_obsoleted_close__isnull=False)
+        player_ids = sorted(set(RunPlayers.objects.values_list("player_id", flat=True)))
+        self.stdout.write(
+            f"{prefix} Resolving obsoleted_at across {len(player_ids)} players..."
         )
 
-        total = candidates.count()
-        self.stdout.write(f"{prefix}Found {total} obsolete runs eligible for backfill.")
-
-        if dry_run or total == 0:
-            return
-
-        updates: list[Runs] = []
-        for run in candidates.only("id", "obsoleted_at"):
-            run.obsoleted_at = run.latest_obsoleted_close
-            updates.append(run)
+        before_null = Runs.objects.filter(
+            obsolete=True, obsoleted_at__isnull=True
+        ).count()
 
         with transaction.atomic():
-            Runs.objects.bulk_update(updates, ["obsoleted_at"], batch_size=500)
+            for player_id in player_ids:
+                _resolve_obsoleted_at_for_player(player_id)
 
-        self.stdout.write(self.style.SUCCESS(f"Backfilled {len(updates)} runs."))
+            after_null = Runs.objects.filter(
+                obsolete=True, obsoleted_at__isnull=True
+            ).count()
+            after_set = Runs.objects.filter(
+                obsolete=True, obsoleted_at__isnull=False
+            ).count()
+
+            self.stdout.write(
+                f"{prefix}obsolete runs now dated: {after_set} "
+                f"(was-null resolved: {before_null - after_null}, "
+                f"still-null/born-obsolete: {after_null})"
+            )
+
+            if dry_run:
+                transaction.set_rollback(True)
+                self.stdout.write(self.style.NOTICE("Dry run completed - rolled back."))
+                return
+
+        self.stdout.write(self.style.SUCCESS("Backfill complete."))

--- a/backend/srl/srcom/leaderboards.py
+++ b/backend/srl/srcom/leaderboards.py
@@ -153,7 +153,7 @@ def _resolve_obsoleted_at_for_player(
             vid_status="verified",
         )
         .exclude(v_date__isnull=True, date__isnull=True)
-        .order_by("v_date", "date")
+        .order_by("date", "v_date")
         .distinct()
     )
     if not player_runs:
@@ -192,7 +192,8 @@ def _resolve_obsoleted_at_for_player(
     updates: list[Runs] = []
     for key, group_runs in groups.items():
         _, game_id, cat_id, level_id, runtype, _ = key
-        group_runs.sort(key=lambda item: (item[0].v_date or item[0].date))  # type: ignore
+
+        group_runs.sort(key=lambda item: (item[0].date or item[0].v_date))  # type: ignore
 
         leaderboard_dict = {
             "game_id": game_id,
@@ -212,7 +213,7 @@ def _resolve_obsoleted_at_for_player(
                 continue
             if rt < pb_time:
                 if pb_run is not None and pb_run.obsolete:
-                    new_obs_at = r.v_date or r.date
+                    new_obs_at = r.date or r.v_date
                     if pb_run.obsoleted_at != new_obs_at:
                         pb_run.obsoleted_at = new_obs_at
                         updates.append(pb_run)

--- a/backend/srl/srcom/utils.py
+++ b/backend/srl/srcom/utils.py
@@ -8,6 +8,7 @@ from django.db.models import Count, F, QuerySet
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from pydantic import RootModel
+
 from srl.models import METHOD_TO_TIME_FIELD as _CANONICAL_METHOD_TO_TIME_FIELD
 from srl.models import Games, Platforms, Players, RunHistory, Runs, VariableValues
 from srl.models.run_history import RunHistoryEndReason
@@ -351,7 +352,7 @@ def apply_player_obsolescence(
         .exclude(**{f"{time_col}__isnull": True})
     )
     base_qs = filter_by_variable_map(base_qs, variable_value_map)
-    base_qs = base_qs.annotate(_eff=Coalesce(F("v_date"), F("date")))
+    base_qs = base_qs.annotate(_eff=Coalesce(F("date"), F("v_date")))
 
     current_obsolete: dict[str, bool] = {}
     keepers: set[str] = set()

--- a/backend/tests/test_run_history.py
+++ b/backend/tests/test_run_history.py
@@ -58,13 +58,12 @@ class RunHistoryOpenRowConstraintTests(TestCase):
             start_date=datetime(2024, 1, 1, tzinfo=_tz.utc),
             points=1000,
         )
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                RunHistory.objects.create(
-                    run=self.target_run,
-                    start_date=datetime(2024, 2, 1, tzinfo=_tz.utc),
-                    points=900,
-                )
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            RunHistory.objects.create(
+                run=self.target_run,
+                start_date=datetime(2024, 2, 1, tzinfo=_tz.utc),
+                points=900,
+            )
 
     def test_closed_rows_do_not_conflict_with_open_row(
         self,

--- a/docker-compose.PROD.yml
+++ b/docker-compose.PROD.yml
@@ -48,7 +48,7 @@ services:
     networks:
       - thpsrun
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8001/api/v1/health').status==200 else 1)"]
+      test: ["CMD", "python", "-c", "import os,urllib.request,sys; h=(os.environ.get('ALLOWED_HOSTS','localhost').split(',')[0].strip().lstrip('.') or 'localhost'); req=urllib.request.Request('http://127.0.0.1:8001/api/v1/health', headers={'Host': h, 'X-Forwarded-Proto': 'https'}); sys.exit(0 if urllib.request.urlopen(req, timeout=8).status==200 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -64,6 +64,8 @@ services:
     depends_on:
       - postgres
       - redis
+    volumes:
+      - media_files:/app/media:rw
     read_only: true
     tmpfs:
       - /tmp


### PR DESCRIPTION
###### August 11, 2026
*   Fixed an issue where the Celery agents would fail to create a backup of the runner's data, since they were never given full access to the `MEDIA_ROOT` folder it would be housed in.
*   Fixed an issue where `v_date` was being used on when it attained a time instead of `date`, resulting in instances where some runs had no `v_date`, were backfilled improperly, and corrupted `RunHistory`. [#135](https://github.com/thpsrun/backend/issues/135)
*   Fixed an issue where the `run_leaderboard_recompute` function could strip world records of their streaks and points in rare circumstances.
    *   It's always THPS3 5th Gen...
*   Fixed some more `N+1` errors.